### PR TITLE
Fix API paths and add feature hooks

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -19,7 +19,7 @@ export const analyticsApi = {
       });
       if (period) params.append('period', period);
       
-      const response = await apiClient.get(`/analytics/station-comparison?${params}`);
+      const response = await apiClient.get(`/stations/compare?${params}`);
       return extractApiArray<StationComparison>(response);
     } catch (error) {
       console.error('Error fetching station comparison:', error);
@@ -72,7 +72,7 @@ export const analyticsApi = {
 
   getStationRanking: async (period: string): Promise<StationRanking[]> => {
     try {
-      const response = await apiClient.get(`/analytics/station-ranking?period=${period}`);
+      const response = await apiClient.get(`/stations/ranking?period=${period}`);
       return extractApiArray<StationRanking>(response);
     } catch (error) {
       console.error('Error fetching station ranking:', error);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -4,8 +4,8 @@
  */
 import axios from 'axios';
 
-// Get the backend URL from environment variables or use the correct API URL
-const API_BASE_URL = 'https://fuelsync-api-demo-bvadbhg8bdbmg0ff.germanywestcentral-01.azurewebsites.net';
+// Base API URL is provided via environment variable for flexibility
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 // Create axios instance with base configuration
 export const apiClient = axios.create({

--- a/src/api/core/apiClient.ts
+++ b/src/api/core/apiClient.ts
@@ -5,8 +5,8 @@
 import axios from 'axios';
 import { convertKeysToCamelCase } from '@/utils/caseConversion';
 
-// Get the backend URL from environment variables or use the correct API URL
-const API_BASE_URL = 'https://fuelsync-api-demo-bvadbhg8bdbmg0ff.germanywestcentral-01.azurewebsites.net';
+// Base API URL is provided via environment variable for flexibility
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 // Create axios instance with base configuration
 const apiClient = axios.create({

--- a/src/api/core/config.ts
+++ b/src/api/core/config.ts
@@ -4,7 +4,7 @@
  */
 
 const API_CONFIG = {
-  baseUrl: import.meta.env.VITE_API_BASE_URL || 'https://fuelsync-api-demo-bvadbhg8bdbmg0ff.germanywestcentral-01.azurewebsites.net',
+  baseUrl: import.meta.env.VITE_API_BASE_URL || '',
   apiPath: '/api/v1',
   endpoints: {
     auth: {

--- a/src/api/fuel-inventory.ts
+++ b/src/api/fuel-inventory.ts
@@ -10,7 +10,7 @@ export const fuelInventoryApi = {
       if (params?.stationId) searchParams.append('stationId', params.stationId);
       if (params?.fuelType) searchParams.append('fuelType', params.fuelType);
       
-      const response = await apiClient.get(`/fuel-inventory?${searchParams.toString()}`);
+      const response = await apiClient.get(`/inventory?${searchParams.toString()}`);
       return extractApiArray<FuelInventory>(response, 'inventory');
     } catch (error) {
       console.error('Error fetching fuel inventory:', error);

--- a/src/api/services/dashboardService.ts
+++ b/src/api/services/dashboardService.ts
@@ -88,7 +88,7 @@ export const dashboardService = {
    * @returns Fuel type breakdown data
    */
   getFuelTypeBreakdown: async (period: string = 'today'): Promise<FuelTypeBreakdown[]> => {
-    const response = await apiClient.get('/dashboard/fuel-types', { params: { period } });
+    const response = await apiClient.get('/dashboard/fuel-breakdown', { params: { period } });
     return extractData<FuelTypeBreakdown[]>(response);
   },
   
@@ -98,7 +98,7 @@ export const dashboardService = {
    * @returns Daily sales trend data
    */
   getDailySalesTrend: async (days: number = 7): Promise<DailySalesTrend[]> => {
-    const response = await apiClient.get('/dashboard/daily-trend', { params: { days } });
+    const response = await apiClient.get('/dashboard/sales-trend', { params: { days } });
     return extractData<DailySalesTrend[]>(response);
   },
   

--- a/src/api/services/inventoryService.ts
+++ b/src/api/services/inventoryService.ts
@@ -26,6 +26,11 @@ export interface FuelInventorySummary {
   totalCurrentStock: number;
 }
 
+export interface InventoryUpdatePayload {
+  id: string;
+  delta: number;
+}
+
 /**
  * Service for fuel inventory API
  */
@@ -40,7 +45,7 @@ export const inventoryService = {
       console.log('[INVENTORY-API] Fetching fuel inventory', stationId ? `for station: ${stationId}` : '');
       
       const params = stationId ? { stationId } : {};
-      const response = await apiClient.get('fuel-inventory', { params });
+      const response = await apiClient.get('inventory', { params });
       
       // Extract inventory from response
       let inventoryArray: FuelInventory[] = [];
@@ -70,13 +75,13 @@ export const inventoryService = {
    * Get fuel inventory summary
    * @returns Fuel inventory summary
    */
-  getInventorySummary: async (): Promise<FuelInventorySummary | null> => {
+  getInventoryAlerts: async (): Promise<FuelInventorySummary | null> => {
     try {
-      console.log('[INVENTORY-API] Fetching inventory summary');
-      const response = await apiClient.get('fuel-inventory/summary');
+      console.log('[INVENTORY-API] Fetching inventory alerts');
+      const response = await apiClient.get('inventory/alerts');
       return extractData<FuelInventorySummary>(response);
     } catch (error) {
-      console.error('[INVENTORY-API] Error fetching inventory summary:', error);
+      console.error('[INVENTORY-API] Error fetching inventory alerts:', error);
       
       // Try to calculate summary from inventory data if API fails
       try {
@@ -111,6 +116,13 @@ export const inventoryService = {
         return null;
       }
     }
+  },
+
+  /**
+   * Update inventory counts
+   */
+  updateInventory: async (payload: InventoryUpdatePayload): Promise<void> => {
+    await apiClient.post('inventory/update', payload);
   }
 };
 

--- a/src/api/stations.ts
+++ b/src/api/stations.ts
@@ -1,6 +1,12 @@
 
 import { apiClient, extractApiData, extractApiArray } from './client';
-import type { Station, ApiResponse } from './api-contract';
+import type {
+  Station,
+  ApiResponse,
+  StationComparison,
+  StationComparisonParams,
+  StationRanking
+} from './api-contract';
 
 export interface CreateStationData {
   name: string;
@@ -60,5 +66,19 @@ export const stationsApi = {
   // Delete station
   deleteStation: async (id: string): Promise<void> => {
     await apiClient.delete(`/stations/${id}`);
+  },
+
+  // Compare stations performance
+  compareStations: async (params: StationComparisonParams): Promise<StationComparison[]> => {
+    const search = new URLSearchParams({ stationIds: params.stationIds.join(',') });
+    if (params.period) search.append('period', params.period);
+    const response = await apiClient.get(`/stations/compare?${search}`);
+    return extractApiArray<StationComparison>(response);
+  },
+
+  // Get station ranking
+  getStationRanking: async (period: string): Promise<StationRanking[]> => {
+    const response = await apiClient.get(`/stations/ranking?period=${period}`);
+    return extractApiArray<StationRanking>(response);
   }
 };

--- a/src/components/analytics/StationComparisonChart.tsx
+++ b/src/components/analytics/StationComparisonChart.tsx
@@ -2,7 +2,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Legend } from 'recharts';
-import { useStationComparison } from '@/hooks/useAnalytics';
+import { useCompareStations } from '@/hooks/useAnalytics';
 import { Building2 } from 'lucide-react';
 
 interface StationComparisonChartProps {
@@ -11,7 +11,7 @@ interface StationComparisonChartProps {
 }
 
 export function StationComparisonChart({ stationIds, period = 'month' }: StationComparisonChartProps) {
-  const { data: comparisonData = [], isLoading } = useStationComparison({ 
+  const { data: comparisonData = [], isLoading } = useCompareStations({
     stationIds, 
     period 
   });

--- a/src/contexts/ApiContext.tsx
+++ b/src/contexts/ApiContext.tsx
@@ -6,7 +6,7 @@ import React, { createContext, useContext, ReactNode } from 'react';
 
 // API configuration
 export const API_CONFIG = {
-  baseUrl: 'https://fuelsync-api-demo-bvadbhg8bdbmg0ff.germanywestcentral-01.azurewebsites.net',
+  baseUrl: import.meta.env.VITE_API_BASE_URL || '',
   endpoints: {
     nozzles: '/api/v1/nozzles',
     pumps: '/api/v1/pumps',

--- a/src/hooks/api/useInventory.ts
+++ b/src/hooks/api/useInventory.ts
@@ -3,8 +3,8 @@
  * @file hooks/api/useInventory.ts
  * @description React Query hooks for fuel inventory API
  */
-import { useQuery } from '@tanstack/react-query';
-import { inventoryService, FuelInventory, FuelInventorySummary } from '@/api/services/inventoryService';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { inventoryService, FuelInventory, FuelInventorySummary, InventoryUpdatePayload } from '@/api/services/inventoryService';
 
 /**
  * Hook to fetch fuel inventory
@@ -13,7 +13,7 @@ import { inventoryService, FuelInventory, FuelInventorySummary } from '@/api/ser
  */
 export const useInventory = (stationId?: string) => {
   return useQuery({
-    queryKey: ['fuel-inventory', stationId],
+    queryKey: ['inventory', stationId],
     queryFn: () => inventoryService.getFuelInventory(stationId),
     staleTime: 60000, // 1 minute
     retry: 2
@@ -24,11 +24,17 @@ export const useInventory = (stationId?: string) => {
  * Hook to fetch fuel inventory summary
  * @returns Query result with inventory summary data
  */
-export const useInventorySummary = () => {
+export const useInventoryAlerts = () => {
   return useQuery({
-    queryKey: ['inventory-summary'],
-    queryFn: () => inventoryService.getInventorySummary(),
+    queryKey: ['inventory-alerts'],
+    queryFn: () => inventoryService.getInventoryAlerts(),
     staleTime: 60000, // 1 minute
     retry: 2
+  });
+};
+
+export const useInventoryUpdate = () => {
+  return useMutation({
+    mutationFn: (payload: InventoryUpdatePayload) => inventoryService.updateInventory(payload)
   });
 };

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -1,12 +1,13 @@
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { analyticsApi } from '@/api/analytics';
+import { stationsApi } from '@/api/stations';
 import { StationComparisonParams } from '@/api/api-contract';
 
-export const useStationComparison = (opts: StationComparisonParams) => {
+export const useCompareStations = (opts: StationComparisonParams) => {
   return useQuery({
-    queryKey: ['analytics', 'station-comparison', opts.stationIds, opts.period],
-    queryFn: () => analyticsApi.getStationComparison(opts),
+    queryKey: ['stations', 'compare', opts.stationIds, opts.period],
+    queryFn: () => stationsApi.compareStations(opts),
     enabled: opts.stationIds.length > 0,
   });
 };
@@ -34,8 +35,8 @@ export const useFuelPerformance = (stationId?: string, dateRange?: { from: Date;
 
 export const useStationRanking = (period: string) => {
   return useQuery({
-    queryKey: ['analytics', 'station-ranking', period],
-    queryFn: () => analyticsApi.getStationRanking(period),
+    queryKey: ['stations', 'ranking', period],
+    queryFn: () => stationsApi.getStationRanking(period),
   });
 };
 

--- a/src/hooks/useFeatureFlags.ts
+++ b/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+import { tenantSettingsApi, TenantSetting } from '@/api/tenant-settings';
+import { useAuth } from '@/contexts/AuthContext';
+
+interface FeatureFlags {
+  [key: string]: string;
+}
+
+export const useFeatureFlags = () => {
+  const { user } = useAuth();
+
+  return useQuery({
+    queryKey: ['feature-flags', user?.tenantId],
+    queryFn: async () => {
+      if (!user?.tenantId) return {} as FeatureFlags;
+      const settings = await tenantSettingsApi.getTenantSettings(user.tenantId);
+      const flags: FeatureFlags = {};
+      settings.forEach((s: TenantSetting) => {
+        if (s.key.startsWith('features.')) {
+          flags[s.key] = s.value;
+        }
+      });
+      return flags;
+    },
+    enabled: !!user?.tenantId,
+  });
+};

--- a/src/hooks/useFuelInventory.ts
+++ b/src/hooks/useFuelInventory.ts
@@ -5,7 +5,7 @@ import { FuelInventoryParams } from '@/api/api-contract';
 
 export const useFuelInventory = (params?: FuelInventoryParams) => {
   return useQuery({
-    queryKey: ['fuel-inventory', params],
+    queryKey: ['inventory', params],
     queryFn: () => fuelInventoryApi.getFuelInventory(params)
   });
 };

--- a/src/hooks/useRoleGuard.ts
+++ b/src/hooks/useRoleGuard.ts
@@ -1,0 +1,16 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/contexts/AuthContext';
+
+export const useRoleGuard = (allowedRoles: string[]) => {
+  const { user, isLoading, isAuthenticated } = useAuth();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isLoading) {
+      if (!isAuthenticated || !user || !allowedRoles.includes(user.role)) {
+        navigate('/unauthorized', { replace: true });
+      }
+    }
+  }, [allowedRoles, user, isLoading, isAuthenticated, navigate]);
+};

--- a/src/pages/dashboard/FuelInventoryPage.tsx
+++ b/src/pages/dashboard/FuelInventoryPage.tsx
@@ -9,7 +9,7 @@ import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Fuel, AlertTriangle, TrendingDown, RefreshCw, Loader2, Download, FileSpreadsheet } from 'lucide-react';
 import { useStations } from '@/hooks/api/useStations';
-import { useInventory, useInventorySummary } from '@/hooks/api/useInventory';
+import { useInventory, useInventoryAlerts } from '@/hooks/api/useInventory';
 import { useGenerateReport } from '@/hooks/api/useReports';
 import { Link, useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
@@ -31,11 +31,11 @@ export default function FuelInventoryPage() {
   } = useInventory(selectedStationId === 'all-stations' ? undefined : selectedStationId);
   
   // Fetch inventory summary
-  const { 
-    data: summary, 
-    isLoading: summaryLoading, 
-    refetch: refetchSummary 
-  } = useInventorySummary();
+  const {
+    data: summary,
+    isLoading: summaryLoading,
+    refetch: refetchSummary
+  } = useInventoryAlerts();
   
   // Generate report mutation
   const generateReport = useGenerateReport();

--- a/src/pages/dashboard/ReadingsPage.tsx
+++ b/src/pages/dashboard/ReadingsPage.tsx
@@ -12,9 +12,11 @@ import { Gauge, Clock, AlertTriangle, CheckCircle, Plus, FileText, Eye, Edit, Lo
 import { useNavigate, Link } from 'react-router-dom';
 import { PageHeader } from '@/components/ui/page-header';
 import { useReadings } from '@/hooks/api/useReadings';
+import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 
 export default function ReadingsPage() {
   const navigate = useNavigate();
+  const { data: features } = useFeatureFlags();
   const [filter, setFilter] = useState<'all' | 'pending' | 'completed' | 'discrepancy'>('all');
   
   // Fetch readings using the API hook
@@ -55,6 +57,11 @@ export default function ReadingsPage() {
 
   return (
     <div className="space-y-6">
+      {features && features['features.auto_sales_generation'] === 'false' && (
+        <div className="bg-yellow-100 text-yellow-800 p-2 rounded text-sm">
+          Automatic sales generation is disabled for this tenant.
+        </div>
+      )}
       <PageHeader
         title="Pump Readings"
         description="Record and monitor fuel pump readings across all stations"

--- a/src/pages/dashboard/StationsPage.tsx
+++ b/src/pages/dashboard/StationsPage.tsx
@@ -11,8 +11,10 @@ import { Label } from '@/components/ui/label';
 import { Badge } from '@/components/ui/badge';
 import { Plus, Eye, Fuel } from 'lucide-react';
 import { useStations } from '@/hooks/api/useStations';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function StationsPage() {
+  useRoleGuard(['owner']);
   const [searchTerm, setSearchTerm] = useState('');
   const { data: stations = [], isLoading, error } = useStations();
 


### PR DESCRIPTION
## Summary
- correct dashboard service endpoints
- move inventory APIs to `/inventory` endpoints
- switch station ranking/comparison to new routes
- centralize base API URL via environment variable
- add hooks for feature flags and role guarding
- show auto sales generation warning on readings page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: dependency resolution conflict)*

------
https://chatgpt.com/codex/tasks/task_e_686777fbb6288320a33bafbf50fba147