### PR TITLE
Document station metrics endpoint

### DIFF
--- a/docs/openapi-spec.yaml
+++ b/docs/openapi-spec.yaml
@@ -1159,6 +1159,14 @@ paths:
           $ref: '#/components/responses/Success'
         default:
           $ref: '#/components/responses/Error'
+  /api/v1/dashboard/station-metrics:
+    get:
+      summary: Dashboard station metrics
+      responses:
+        '200':
+          $ref: '#/components/responses/Success'
+        default:
+          $ref: '#/components/responses/Error'
   /api/v1/tenants:
     get:
       summary: List tenants
@@ -2004,6 +2012,30 @@ paths:
         margin:
           type: number
         growth:
+          type: number
+    StationMetric:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        todaySales:
+          type: number
+        monthlySales:
+          type: number
+        salesGrowth:
+          type: number
+        activePumps:
+          type: number
+        totalPumps:
+          type: number
+        status:
+          type: string
+          enum: [active, inactive, maintenance]
+        lastActivity:
+          type: string
+        efficiency:
           type: number
     StationRanking:
       type: object


### PR DESCRIPTION
## Summary
- add `/dashboard/station-metrics` to OpenAPI spec
- define `StationMetric` schema

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686786dcdf288320981a021c1d75f8a1