### PR TITLE
Use API data in DataMappingContext

### DIFF
--- a/src/contexts/DataMappingContext.tsx
+++ b/src/contexts/DataMappingContext.tsx
@@ -2,13 +2,16 @@
 
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useAuth } from './AuthContext';
+import { nozzlesService, Nozzle } from '@/api/services/nozzlesService';
+import { pumpsService, Pump } from '@/api/services/pumpsService';
+import { stationsService, Station } from '@/api/services/stationsService';
 
 interface DataMappingContextType {
   mapApiData: <T,>(data: any, mapping?: Record<string, string>) => T;
   mapArrayData: <T,>(data: any[], mapping?: Record<string, string>) => T[];
-  getStationByNozzleId: (nozzleId: string) => string;
-  getNozzleNumber: (nozzleId: string) => number;
-  getNozzleFuelType: (nozzleId: string) => string;
+  getStationByNozzleId: (nozzleId: string) => Promise<string>;
+  getNozzleNumber: (nozzleId: string) => Promise<number>;
+  getNozzleFuelType: (nozzleId: string) => Promise<string>;
   isReady: boolean;
   isLoading: boolean;
 }
@@ -58,21 +61,78 @@ export function DataMappingProvider({ children }: DataMappingProviderProps) {
     return data.map(item => mapApiData<T>(item, mapping));
   };
 
-  // Simple placeholder implementations for nozzle/station mapping
-  const getStationByNozzleId = (nozzleId: string): string => {
-    // TODO: Implement actual station lookup logic
-    return `Station-${nozzleId.slice(-2)}`;
+  // Local caches to avoid repeated API calls
+  const nozzleCache = React.useRef<Map<string, Nozzle>>(new Map());
+  const pumpCache = React.useRef<Map<string, Pump>>(new Map());
+  const stationCache = React.useRef<Map<string, Station>>(new Map());
+
+  const fetchNozzle = async (id: string): Promise<Nozzle | null> => {
+    if (nozzleCache.current.has(id)) {
+      return nozzleCache.current.get(id)!;
+    }
+    try {
+      const nozzle = await nozzlesService.getNozzle(id);
+      nozzleCache.current.set(id, nozzle);
+      return nozzle;
+    } catch (error) {
+      console.error('[DATA-MAPPING] Failed to fetch nozzle', id, error);
+      return null;
+    }
   };
 
-  const getNozzleNumber = (nozzleId: string): number => {
-    // TODO: Implement actual nozzle number lookup
-    const match = nozzleId.match(/(\d+)$/);
-    return match ? parseInt(match[1], 10) : 1;
+  const fetchPump = async (id: string): Promise<Pump | null> => {
+    if (pumpCache.current.has(id)) {
+      return pumpCache.current.get(id)!;
+    }
+    try {
+      const pump = await pumpsService.getPump(id);
+      pumpCache.current.set(id, pump);
+      return pump;
+    } catch (error) {
+      console.error('[DATA-MAPPING] Failed to fetch pump', id, error);
+      return null;
+    }
   };
 
-  const getNozzleFuelType = (nozzleId: string): string => {
-    // TODO: Implement actual fuel type lookup
-    return 'petrol'; // Default fuel type
+  const fetchStation = async (id: string): Promise<Station | null> => {
+    if (stationCache.current.has(id)) {
+      return stationCache.current.get(id)!;
+    }
+    try {
+      const station = await stationsService.getStation(id);
+      stationCache.current.set(id, station);
+      return station;
+    } catch (error) {
+      console.error('[DATA-MAPPING] Failed to fetch station', id, error);
+      return null;
+    }
+  };
+
+  const getStationByNozzleId = async (nozzleId: string): Promise<string> => {
+    const nozzle = await fetchNozzle(nozzleId);
+    if (!nozzle) return '';
+
+    let stationId = (nozzle as any).stationId as string | undefined;
+
+    if (!stationId && nozzle.pumpId) {
+      const pump = await fetchPump(nozzle.pumpId);
+      stationId = pump?.stationId;
+    }
+
+    if (!stationId) return '';
+
+    const station = await fetchStation(stationId);
+    return station?.name || '';
+  };
+
+  const getNozzleNumber = async (nozzleId: string): Promise<number> => {
+    const nozzle = await fetchNozzle(nozzleId);
+    return nozzle?.nozzleNumber ?? 0;
+  };
+
+  const getNozzleFuelType = async (nozzleId: string): Promise<string> => {
+    const nozzle = await fetchNozzle(nozzleId);
+    return nozzle?.fuelType || '';
   };
 
   const value: DataMappingContextType = {


### PR DESCRIPTION
## Summary
- fetch station and nozzle details from APIs instead of using placeholders
- add local caches for nozzle, pump and station data
- expose async mapping helpers

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68678af3818083208ce3ca01a15fd692