### PR TITLE
Standardize alert ID parameter

### DIFF
--- a/docs/openapi-spec.yaml
+++ b/docs/openapi-spec.yaml
@@ -664,11 +664,11 @@ paths:
                     $ref: '#/components/schemas/AlertSummary'
         default:
           $ref: '#/components/responses/Error'
-  /api/v1/alerts/{alertId}:
+  /api/v1/alerts/{id}:
     delete:
       summary: Delete an alert by ID
       parameters:
-        - name: alertId
+        - name: id
           in: path
           required: true
           schema:

--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -17,11 +17,11 @@ export const alertsApi = {
     }
   },
 
-  markAsRead: async (alertId: string): Promise<void> => {
-    await apiClient.patch(`/alerts/${alertId}/read`);
+  markAsRead: async (id: string): Promise<void> => {
+    await apiClient.patch(`/alerts/${id}/read`);
   },
 
-  dismissAlert: async (alertId: string): Promise<void> => {
-    await apiClient.delete(`/alerts/${alertId}`);
+  dismissAlert: async (id: string): Promise<void> => {
+    await apiClient.delete(`/alerts/${id}`);
   },
 };

--- a/src/api/attendant.ts
+++ b/src/api/attendant.ts
@@ -77,9 +77,9 @@ export const attendantApi = {
   },
 
   // Acknowledge alert
-  acknowledgeAlert: async (alertId: string): Promise<void> => {
-    devLog('Acknowledging alert', alertId);
-    await apiClient.put(`/attendant/alerts/${alertId}/acknowledge`);
+  acknowledgeAlert: async (id: string): Promise<void> => {
+    devLog('Acknowledging alert', id);
+    await apiClient.put(`/attendant/alerts/${id}/acknowledge`);
   }
 };
 

--- a/src/api/contract/attendant.service.ts
+++ b/src/api/contract/attendant.service.ts
@@ -82,10 +82,10 @@ export class AttendantService {
 
   /**
    * Acknowledge alert
-   * PUT /attendant/alerts/{alertId}/acknowledge
+   * PUT /attendant/alerts/{id}/acknowledge
    */
-  async acknowledgeAlert(alertId: string): Promise<void> {
-    return contractClient.put<void>(`/attendant/alerts/${alertId}/acknowledge`);
+  async acknowledgeAlert(id: string): Promise<void> {
+    return contractClient.put<void>(`/attendant/alerts/${id}/acknowledge`);
   }
 }
 

--- a/src/components/alerts/AlertBadge.tsx
+++ b/src/components/alerts/AlertBadge.tsx
@@ -24,12 +24,12 @@ export function AlertBadge() {
     }
   };
 
-  const handleMarkAsRead = (alertId: string) => {
-    markAsRead(alertId);
+  const handleMarkAsRead = (id: string) => {
+    markAsRead(id);
   };
 
-  const handleDismiss = (alertId: string) => {
-    dismissAlert(alertId);
+  const handleDismiss = (id: string) => {
+    dismissAlert(id);
   };
 
   if (unreadAlerts.length === 0) {

--- a/src/components/alerts/SystemAlertsPanel.tsx
+++ b/src/components/alerts/SystemAlertsPanel.tsx
@@ -12,8 +12,8 @@ export function SystemAlertsPanel() {
   const { data: missingPrices = [] } = useMissingFuelPrices();
   const acknowledgeAlert = useAcknowledgeAlert();
 
-  const handleAcknowledge = (alertId: string) => {
-    acknowledgeAlert.mutate(alertId);
+  const handleAcknowledge = (id: string) => {
+    acknowledgeAlert.mutate(id);
   };
 
   const getPriorityColor = (priority: string) => {

--- a/src/hooks/useAttendant.ts
+++ b/src/hooks/useAttendant.ts
@@ -82,7 +82,7 @@ export const useAcknowledgeAlert = () => {
   const { toast } = useToast();
 
   return useMutation({
-    mutationFn: (alertId: string) => attendantApi.acknowledgeAlert(alertId),
+    mutationFn: (id: string) => attendantApi.acknowledgeAlert(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['attendant', 'alerts'] });
       toast({


### PR DESCRIPTION
## Summary
- fix path parameter for deleting alerts to use `{id}`
- update attendant alert API helpers for `{id}`
- adjust components and hooks to match the new parameter
- regenerate openapi spec entry for alert deletion

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867902261c883209a06986862a78cf8