### PR TITLE
Add system health hook

### DIFF
--- a/src/api/api-contract.ts
+++ b/src/api/api-contract.ts
@@ -421,6 +421,12 @@ export interface StationMetric {
   efficiency?: number;
 }
 
+export interface SystemHealth {
+  uptime: number;
+  responseTime: number;
+  errorRate: number;
+}
+
 // =============================================================================
 // SUPERADMIN TYPES
 // =============================================================================

--- a/src/api/contract/owner.service.ts
+++ b/src/api/contract/owner.service.ts
@@ -21,7 +21,8 @@ import type {
   Creditor,
   CreateCreditorRequest,
   SalesSummary,
-  PaymentMethodBreakdown
+  PaymentMethodBreakdown,
+  SystemHealth
 } from '../api-contract';
 
 export class OwnerService {
@@ -223,6 +224,14 @@ export class OwnerService {
    */
   async getPaymentMethods(): Promise<PaymentMethodBreakdown[]> {
     return contractClient.getArray<PaymentMethodBreakdown>('/dashboard/payment-methods', 'paymentMethods');
+  }
+
+  /**
+   * Get system health metrics
+   * GET /dashboard/system-health
+   */
+  async getSystemHealth(): Promise<SystemHealth> {
+    return contractClient.get<SystemHealth>('/dashboard/system-health');
   }
 }
 

--- a/src/hooks/useSystemHealth.ts
+++ b/src/hooks/useSystemHealth.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { ownerService } from '@/api/contract/owner.service';
+
+export const useSystemHealth = () => {
+  return useQuery({
+    queryKey: ['system-health'],
+    queryFn: () => ownerService.getSystemHealth(),
+    staleTime: 60000,
+  });
+};

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -13,6 +13,7 @@ import { usePumps } from '@/hooks/api/usePumps';
 import { useFuelPrices } from '@/hooks/api/useFuelPrices';
 import { useReadings } from '@/hooks/api/useReadings';
 import { useAnalyticsDashboard, useAdminDashboard } from '@/hooks/useDashboard';
+import { useSystemHealth } from '@/hooks/useSystemHealth';
 import { EnhancedMetricsCard } from '@/components/ui/enhanced-metrics-card';
 import { Link } from 'react-router-dom';
 
@@ -29,6 +30,7 @@ export default function DashboardPage() {
   // Fetch analytics data
   const { data: analytics, isLoading: analyticsLoading, refetch: refetchAnalytics } = useAnalyticsDashboard();
   const { data: adminData, isLoading: adminLoading, refetch: refetchAdmin } = useAdminDashboard();
+  const { data: systemHealth } = useSystemHealth();
   
   // Calculate metrics
   const totalRevenue = readings.reduce((sum, reading) => sum + (reading.amount || 0), 0);
@@ -131,7 +133,7 @@ export default function DashboardPage() {
           
           <EnhancedMetricsCard
             title="System Health"
-            value="99.9%"
+            value={systemHealth ? `${systemHealth.uptime.toFixed(1)}%` : 'N/A'}
             icon={<Shield className="h-5 w-5" />}
             description="Platform uptime"
             gradient="from-green-500 to-emerald-600"

--- a/src/pages/superadmin/AnalyticsPage.tsx
+++ b/src/pages/superadmin/AnalyticsPage.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/button';
 import { RefreshCw } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { useSystemHealth } from '@/hooks/useSystemHealth';
 
 export default function AnalyticsPage() {
   const { data: analytics, isLoading, error, refetch, isRefetching } = useQuery({
@@ -17,6 +18,7 @@ export default function AnalyticsPage() {
     retry: 2,
     staleTime: 300000, // 5 minutes
   });
+  const { data: systemHealth } = useSystemHealth();
 
   if (isLoading) {
     return (
@@ -142,7 +144,7 @@ export default function AnalyticsPage() {
 
             <EnhancedMetricsCard
               title="System Health"
-              value="99.9%"
+              value={systemHealth ? `${systemHealth.uptime.toFixed(1)}%` : 'N/A'}
               icon={<Shield className="h-5 w-5" />}
               description="Platform uptime"
               gradient="from-teal-400 to-green-500"


### PR DESCRIPTION
## Summary
- define `SystemHealth` type
- add `getSystemHealth` API call in contract owner service
- create `useSystemHealth` hook
- show actual uptime in dashboard and analytics pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68679fda3e948320aef14795d516f0de