### PR TITLE
Add tenant analytics API hooks

### DIFF
--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -84,4 +84,14 @@ export const analyticsApi = {
     const response = await apiClient.get('/analytics/superadmin');
     return extractApiData<SuperAdminAnalytics>(response);
   },
+
+  getDashboardAnalytics: async (): Promise<SuperAdminAnalytics> => {
+    const response = await apiClient.get('/analytics/dashboard');
+    return extractApiData<SuperAdminAnalytics>(response);
+  },
+
+  getTenantAnalytics: async (tenantId: string): Promise<SuperAdminAnalytics> => {
+    const response = await apiClient.get(`/analytics/tenant/${tenantId}`);
+    return extractApiData<SuperAdminAnalytics>(response);
+  },
 };

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -46,3 +46,18 @@ export const useSuperAdminAnalytics = () => {
     queryFn: () => analyticsApi.getSuperAdminAnalytics(),
   });
 };
+
+export const useDashboardAnalytics = () => {
+  return useQuery({
+    queryKey: ['analytics', 'dashboard'],
+    queryFn: () => analyticsApi.getDashboardAnalytics(),
+  });
+};
+
+export const useTenantAnalytics = (tenantId: string) => {
+  return useQuery({
+    queryKey: ['analytics', 'tenant', tenantId],
+    queryFn: () => analyticsApi.getTenantAnalytics(tenantId),
+    enabled: !!tenantId,
+  });
+};

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -67,7 +67,7 @@ export const useStationMetrics = () => {
 export const useAnalyticsDashboard = () => {
   return useQuery({
     queryKey: ['analytics-dashboard'],
-    queryFn: () => analyticsApi.getSuperAdminAnalytics(),
+    queryFn: () => analyticsApi.getDashboardAnalytics(),
     retry: 1,
     staleTime: 300000, // 5 minutes
   });

--- a/src/pages/dashboard/AnalyticsPage.tsx
+++ b/src/pages/dashboard/AnalyticsPage.tsx
@@ -3,15 +3,23 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { BarChart3, TrendingUp, Users, Fuel, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
+import { useDashboardAnalytics } from '@/hooks/useAnalytics';
 
 export default function AnalyticsPage() {
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const { data: analytics, isLoading, refetch } = useDashboardAnalytics();
 
   const handleRefresh = async () => {
     setIsRefreshing(true);
-    // Simulate refresh
-    setTimeout(() => setIsRefreshing(false), 1000);
+    await refetch();
+    setIsRefreshing(false);
   };
+
+  if (isLoading) {
+    return (
+      <div className="py-12 text-center text-muted-foreground">Loading analytics...</div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -22,7 +30,7 @@ export default function AnalyticsPage() {
             Business insights and performance metrics
           </p>
         </div>
-        <Button onClick={handleRefresh} disabled={isRefreshing} variant="outline" size="sm">
+        <Button onClick={handleRefresh} disabled={isRefreshing || isLoading} variant="outline" size="sm">
           <RefreshCw className={`mr-2 h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
           Refresh
         </Button>
@@ -36,7 +44,9 @@ export default function AnalyticsPage() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">₹0</div>
+            <div className="text-2xl font-bold">
+              ₹{(analytics?.totalRevenue ?? 0).toLocaleString()}
+            </div>
             <p className="text-xs text-muted-foreground">
               +0% from last month
             </p>
@@ -49,7 +59,9 @@ export default function AnalyticsPage() {
             <Fuel className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0L</div>
+            <div className="text-2xl font-bold">
+              {(analytics?.salesVolume ?? analytics?.totalVolume ?? 0).toLocaleString()}L
+            </div>
             <p className="text-xs text-muted-foreground">
               +0% from last month
             </p>
@@ -62,7 +74,9 @@ export default function AnalyticsPage() {
             <BarChart3 className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
+            <div className="text-2xl font-bold">
+              {analytics?.transactionCount ?? analytics?.transactions ?? 0}
+            </div>
             <p className="text-xs text-muted-foreground">
               +0% from last month
             </p>
@@ -75,7 +89,9 @@ export default function AnalyticsPage() {
             <Users className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">0</div>
+            <div className="text-2xl font-bold">
+              {analytics?.activeStations ?? analytics?.stationCount ?? 0}
+            </div>
             <p className="text-xs text-muted-foreground">
               All stations operational
             </p>

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -12,7 +12,8 @@ import { useStations } from '@/hooks/api/useStations';
 import { usePumps } from '@/hooks/api/usePumps';
 import { useFuelPrices } from '@/hooks/api/useFuelPrices';
 import { useReadings } from '@/hooks/api/useReadings';
-import { useAnalyticsDashboard, useAdminDashboard } from '@/hooks/useDashboard';
+import { useAdminDashboard } from '@/hooks/useDashboard';
+import { useDashboardAnalytics } from '@/hooks/useAnalytics';
 import { useSystemHealth } from '@/hooks/useSystemHealth';
 import { EnhancedMetricsCard } from '@/components/ui/enhanced-metrics-card';
 import { Link } from 'react-router-dom';
@@ -28,7 +29,7 @@ export default function DashboardPage() {
   const { data: readings = [], isLoading: readingsLoading, refetch: refetchReadings } = useReadings();
   
   // Fetch analytics data
-  const { data: analytics, isLoading: analyticsLoading, refetch: refetchAnalytics } = useAnalyticsDashboard();
+  const { data: analytics, isLoading: analyticsLoading, refetch: refetchAnalytics } = useDashboardAnalytics();
   const { data: adminData, isLoading: adminLoading, refetch: refetchAdmin } = useAdminDashboard();
   const { data: systemHealth } = useSystemHealth();
   


### PR DESCRIPTION
## Summary
- add new API functions for analytics dashboard and tenant analytics
- expose new hooks for dashboard and tenant analytics
- wire analytics dashboard hook into dashboard pages
- show analytics data on analytics page

## Testing
- `npx vitest run` *(fails: needs vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_6867a2382cf8832083ae1b70bde22959