### PR TITLE
Add station metrics endpoints

### DIFF
--- a/src/api/services/stationsService.ts
+++ b/src/api/services/stationsService.ts
@@ -7,6 +7,7 @@
 import apiClient, { extractData, extractArray } from '../core/apiClient';
 import API_CONFIG from '../core/config';
 import { ApiResponse } from '../types/responses';
+import type { StationMetric, StationComparison } from '../api-contract';
 
 // Types
 export interface Station {
@@ -122,6 +123,55 @@ export const stationsService = {
       await apiClient.delete(`/stations/${id}`);
     } catch (error) {
       console.error(`[STATIONS-SERVICE] Error deleting station ${id}:`, error);
+      throw error;
+    }
+  },
+
+  /**
+   * Get metrics for a station
+   * @param id Station ID
+   * @returns Station metrics data
+   */
+  getStationMetrics: async (id: string): Promise<StationMetric> => {
+    try {
+      const url = API_CONFIG.endpoints.stations.metrics(id);
+      const response = await apiClient.get(url);
+      return extractData<StationMetric>(response);
+    } catch (error) {
+      console.error(`[STATIONS-SERVICE] Error fetching metrics for station ${id}:`, error);
+      throw error;
+    }
+  },
+
+  /**
+   * Get performance comparison for a station
+   * @param id Station ID
+   * @returns Performance metrics
+   */
+  getStationPerformance: async (id: string): Promise<StationComparison[]> => {
+    try {
+      const url = API_CONFIG.endpoints.stations.performance(id);
+      const response = await apiClient.get(url);
+      return extractArray<StationComparison>(response, 'data');
+    } catch (error) {
+      console.error(`[STATIONS-SERVICE] Error fetching performance for station ${id}:`, error);
+      throw error;
+    }
+  },
+
+  /**
+   * Get efficiency metric for a station
+   * @param id Station ID
+   * @returns Efficiency percentage
+   */
+  getStationEfficiency: async (id: string): Promise<number> => {
+    try {
+      const url = API_CONFIG.endpoints.stations.efficiency(id);
+      const response = await apiClient.get(url);
+      const data = extractData<{ efficiency: number }>(response);
+      return data.efficiency;
+    } catch (error) {
+      console.error(`[STATIONS-SERVICE] Error fetching efficiency for station ${id}:`, error);
       throw error;
     }
   }

--- a/src/hooks/api/useStations.ts
+++ b/src/hooks/api/useStations.ts
@@ -5,6 +5,8 @@
  */
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { stationsApi, CreateStationData, UpdateStationData } from '@/api/stations';
+import { stationsService } from '@/api/services/stationsService';
+import type { StationMetric, StationComparison } from '@/api/api-contract';
 
 /**
  * Hook to fetch all stations
@@ -69,11 +71,47 @@ export const useUpdateStation = () => {
  */
 export const useDeleteStation = () => {
   const queryClient = useQueryClient();
-  
+
   return useMutation({
     mutationFn: (id: string) => stationsApi.deleteStation(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['stations'] });
     },
+  });
+};
+
+/**
+ * Hook to fetch metrics for a station
+ */
+export const useStationMetrics = (id: string) => {
+  return useQuery({
+    queryKey: ['station', id, 'metrics'],
+    queryFn: () => stationsService.getStationMetrics(id),
+    enabled: !!id,
+    staleTime: 60000,
+  });
+};
+
+/**
+ * Hook to fetch performance data for a station
+ */
+export const useStationPerformance = (id: string) => {
+  return useQuery({
+    queryKey: ['station', id, 'performance'],
+    queryFn: () => stationsService.getStationPerformance(id),
+    enabled: !!id,
+    staleTime: 60000,
+  });
+};
+
+/**
+ * Hook to fetch efficiency metric for a station
+ */
+export const useStationEfficiency = (id: string) => {
+  return useQuery({
+    queryKey: ['station', id, 'efficiency'],
+    queryFn: () => stationsService.getStationEfficiency(id),
+    enabled: !!id,
+    staleTime: 60000,
   });
 };

--- a/src/pages/dashboard/StationDetailPage.tsx
+++ b/src/pages/dashboard/StationDetailPage.tsx
@@ -21,7 +21,7 @@ import {
   DollarSign,
   TrendingUp
 } from 'lucide-react';
-import { useStation } from '@/hooks/api/useStations';
+import { useStation, useStationMetrics, useStationPerformance, useStationEfficiency } from '@/hooks/api/useStations';
 import { usePumps } from '@/hooks/api/usePumps';
 
 export default function StationDetailPage() {
@@ -29,6 +29,9 @@ export default function StationDetailPage() {
   const navigate = useNavigate();
   const { data: station, isLoading, error } = useStation(stationId!);
   const { data: pumps = [] } = usePumps(stationId);
+  const { data: metrics } = useStationMetrics(stationId!);
+  const { data: performance } = useStationPerformance(stationId!);
+  const { data: efficiency } = useStationEfficiency(stationId!);
 
   if (isLoading) {
     return (
@@ -75,17 +78,17 @@ export default function StationDetailPage() {
       </div>
 
       {/* Station Overview Cards */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
             <CardTitle className="text-sm font-medium">Today's Sales</CardTitle>
             <DollarSign className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">₹{(station as any).todaySales?.toLocaleString() || '0'}</div>
+            <div className="text-2xl font-bold">₹{metrics?.todaySales?.toLocaleString() || '0'}</div>
             <p className="text-xs text-muted-foreground">
-              {(station as any).salesGrowth ? 
-                `+${(station as any).salesGrowth}% from yesterday` : 
+              {metrics?.salesGrowth != null ?
+                `+${metrics.salesGrowth}% from yesterday` :
                 'No growth data available'
               }
             </p>
@@ -98,7 +101,7 @@ export default function StationDetailPage() {
             <TrendingUp className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">₹{(station as any).monthlySales?.toLocaleString() || '0'}</div>
+            <div className="text-2xl font-bold">₹{metrics?.monthlySales?.toLocaleString() || '0'}</div>
             <p className="text-xs text-muted-foreground">
               Current month performance
             </p>
@@ -111,13 +114,41 @@ export default function StationDetailPage() {
             <Fuel className="h-4 w-4 text-muted-foreground" />
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold">{pumps.length}</div>
+            <div className="text-2xl font-bold">{metrics?.activePumps ?? pumps.length}</div>
             <p className="text-xs text-muted-foreground">
               Total pumps configured
             </p>
           </CardContent>
         </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Efficiency</CardTitle>
+            <BarChart3 className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{Number(efficiency ?? metrics?.efficiency ?? 0).toFixed(2)}%</div>
+            <p className="text-xs text-muted-foreground">Operational efficiency</p>
+          </CardContent>
+        </Card>
       </div>
+
+      {performance && performance.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Performance</CardTitle>
+            <CardDescription>Period: {performance[0].period}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div>Revenue: ₹{performance[0].revenue.toLocaleString()}</div>
+              <div>Volume: {performance[0].volume.toLocaleString()} L</div>
+              <div>Sales: {performance[0].salesCount}</div>
+              <div>Growth: {performance[0].growth}%</div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Pumps Grid */}
       <Card>


### PR DESCRIPTION
## Summary
- extend stations service with metrics, performance and efficiency API calls
- expose React hooks for new station endpoints
- display metrics, performance and efficiency on station detail pages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867aa56267c8320b1ac99315363069d