### PR TITLE
Fix lint dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,14 @@ git clone <YOUR_GIT_URL>
 # Step 2: Navigate to the project directory.
 cd <YOUR_PROJECT_NAME>
 
-# Step 3: Install the necessary dependencies.
-npm i
+# Step 3: Install the necessary dependencies. The project has some peer
+# dependency conflicts, so use the legacy flag when installing.
+npm i --legacy-peer-deps
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: (optional) Run the linter to verify everything works.
+npm run lint
+
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 


### PR DESCRIPTION
## Summary
- fix missing lint deps by clarifying install steps

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6867ad9b848083209e9ff783900e001f