### PR TITLE
Add role guards to protected pages

### DIFF
--- a/src/pages/dashboard/AnalyticsPage.tsx
+++ b/src/pages/dashboard/AnalyticsPage.tsx
@@ -4,8 +4,10 @@ import { Button } from '@/components/ui/button';
 import { BarChart3, TrendingUp, Users, Fuel, RefreshCw } from 'lucide-react';
 import { useState } from 'react';
 import { useDashboardAnalytics } from '@/hooks/useAnalytics';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function AnalyticsPage() {
+  useRoleGuard(['owner', 'manager']);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const { data: analytics, isLoading, refetch } = useDashboardAnalytics();
 

--- a/src/pages/dashboard/AttendantDashboardPage.tsx
+++ b/src/pages/dashboard/AttendantDashboardPage.tsx
@@ -13,8 +13,10 @@ import { useFuelPrices } from '@/hooks/api/useFuelPrices';
 import { format } from 'date-fns';
 import { Loader2, FileText, Fuel, CreditCard, DollarSign } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function AttendantDashboardPage() {
+  useRoleGuard(['attendant']);
   const [selectedDate, setSelectedDate] = useState(format(new Date(), 'yyyy-MM-dd'));
   const [selectedStationId, setSelectedStationId] = useState<string | undefined>();
   

--- a/src/pages/dashboard/CashReportPage.tsx
+++ b/src/pages/dashboard/CashReportPage.tsx
@@ -4,6 +4,7 @@
  */
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -18,6 +19,7 @@ import { ArrowLeft, Plus, Trash, DollarSign, CreditCard, Loader2 } from 'lucide-
 import { CashReport, CreditEntry } from '@/api/services/attendantService';
 
 export default function CashReportPage() {
+  useRoleGuard(['attendant']);
   const navigate = useNavigate();
   const { toast } = useToast();
   const today = format(new Date(), 'yyyy-MM-dd');

--- a/src/pages/dashboard/CashReportsListPage.tsx
+++ b/src/pages/dashboard/CashReportsListPage.tsx
@@ -4,6 +4,7 @@
  */
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useStations } from '@/hooks/api/useStations';
@@ -13,6 +14,7 @@ import { ArrowLeft, RefreshCw, Loader2, DollarSign } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 
 export default function CashReportsListPage() {
+  useRoleGuard(['attendant']);
   const navigate = useNavigate();
   const [isRefreshing, setIsRefreshing] = useState(false);
   

--- a/src/pages/dashboard/CreateNozzlePage.tsx
+++ b/src/pages/dashboard/CreateNozzlePage.tsx
@@ -12,11 +12,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ArrowLeft, Loader2 } from 'lucide-react';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { usePump } from '@/hooks/api/usePumps';
 import { useCreateNozzle } from '@/hooks/api/useNozzles';
 import { useToast } from '@/hooks/use-toast';
 
 export default function CreateNozzlePage() {
+  useRoleGuard(['owner', 'manager']);
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const { toast } = useToast();

--- a/src/pages/dashboard/CreatePumpPage.tsx
+++ b/src/pages/dashboard/CreatePumpPage.tsx
@@ -14,6 +14,7 @@ import { useContractStations } from '@/hooks/useContractStations';
 import { toast } from '@/hooks/use-toast';
 import { pumpsApi } from '@/api/pumps';
 import { ownerService } from '@/api/contract/owner.service';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 const createPumpSchema = z.object({
   name: z.string().min(1, 'Pump name is required'),
@@ -24,6 +25,7 @@ const createPumpSchema = z.object({
 type CreatePumpForm = z.infer<typeof createPumpSchema>;
 
 export default function CreatePumpPage() {
+  useRoleGuard(['owner', 'manager']);
   const navigate = useNavigate();
   const { data: stations = [], isLoading: stationsLoading } = useContractStations();
   

--- a/src/pages/dashboard/CreateStationPage.tsx
+++ b/src/pages/dashboard/CreateStationPage.tsx
@@ -8,8 +8,10 @@ import { Label } from '@/components/ui/label';
 import { ArrowLeft, Building2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { stationsApi } from '@/api/stations';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function CreateStationPage() {
+  useRoleGuard(['owner', 'manager']);
   const navigate = useNavigate();
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(false);

--- a/src/pages/dashboard/CreditorPaymentsPage.tsx
+++ b/src/pages/dashboard/CreditorPaymentsPage.tsx
@@ -7,8 +7,10 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useNavigate } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function CreditorPaymentsPage() {
+  useRoleGuard(['owner', 'manager']);
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: creditor, isLoading } = useCreditor(id!);

--- a/src/pages/dashboard/CreditorsPage.tsx
+++ b/src/pages/dashboard/CreditorsPage.tsx
@@ -8,8 +8,10 @@ import { CreditorList } from '@/components/creditors/CreditorList';
 import { CreditorForm } from '@/components/creditors/CreditorForm';
 import { useCreditors } from '@/hooks/useCreditors';
 import { useAuth } from '@/contexts/AuthContext';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function CreditorsPage() {
+  useRoleGuard(['owner', 'manager']);
   const [showForm, setShowForm] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
   const { user } = useAuth();

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -17,8 +17,10 @@ import { useDashboardAnalytics } from '@/hooks/useAnalytics';
 import { useSystemHealth } from '@/hooks/useSystemHealth';
 import { EnhancedMetricsCard } from '@/components/ui/enhanced-metrics-card';
 import { Link } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function DashboardPage() {
+  useRoleGuard(['owner', 'manager']);
   const { user } = useAuth();
   const [isRefreshing, setIsRefreshing] = useState(false);
   

--- a/src/pages/dashboard/FuelDeliveriesPage.tsx
+++ b/src/pages/dashboard/FuelDeliveriesPage.tsx
@@ -3,8 +3,10 @@ import { useFuelDeliveries } from '@/hooks/useFuelDeliveries';
 import { DeliveryTable } from '@/components/fuel-deliveries/DeliveryTable';
 import { DeliveryForm } from '@/components/fuel-deliveries/DeliveryForm';
 import { ErrorFallback } from '@/components/common/ErrorFallback';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function FuelDeliveriesPage() {
+  useRoleGuard(['owner', 'manager']);
   const { data: deliveriesData, isLoading, error, refetch } = useFuelDeliveries();
 
   // Ensure we always have an array to work with

--- a/src/pages/dashboard/FuelInventoryPage.tsx
+++ b/src/pages/dashboard/FuelInventoryPage.tsx
@@ -14,8 +14,10 @@ import { useDeliveriesInventory } from '@/hooks/useFuelDeliveries';
 import { useGenerateReport } from '@/hooks/api/useReports';
 import { Link, useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function FuelInventoryPage() {
+  useRoleGuard(['owner', 'manager']);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [selectedStationId, setSelectedStationId] = useState('all-stations');
   const navigate = useNavigate();

--- a/src/pages/dashboard/FuelPricesPage.tsx
+++ b/src/pages/dashboard/FuelPricesPage.tsx
@@ -12,6 +12,7 @@ import { FuelPriceForm } from '@/components/fuel-prices/FuelPriceForm';
 import { PageHeader } from '@/components/ui/page-header';
 import { TooltipWrapper } from '@/components/ui/tooltip-wrapper';
 import { useFuelPrices } from '@/hooks/api/useFuelPrices';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 /**
  * Fuel Prices management page
@@ -23,6 +24,7 @@ import { useFuelPrices } from '@/hooks/api/useFuelPrices';
  * - Clear user feedback and navigation
  */
 export default function FuelPricesPage() {
+  useRoleGuard(['owner', 'manager']);
   const [showForm, setShowForm] = useState(false);
   const { refetch, isLoading } = useFuelPrices();
 

--- a/src/pages/dashboard/InventoryPage.tsx
+++ b/src/pages/dashboard/InventoryPage.tsx
@@ -1,8 +1,10 @@
 
 import { useFuelInventory } from '@/hooks/useFuelInventory';
 import { InventoryTable } from '@/components/fuel-deliveries/InventoryTable';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function InventoryPage() {
+  useRoleGuard(['owner', 'manager']);
   const { data: inventory = [], isLoading } = useFuelInventory();
 
   return (

--- a/src/pages/dashboard/NewReadingPage.tsx
+++ b/src/pages/dashboard/NewReadingPage.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -20,6 +21,7 @@ import { useFuelPrices } from '@/hooks/api/useFuelPrices';
 import { useToast } from '@/hooks/use-toast';
 
 export default function NewReadingPage() {
+  useRoleGuard(['owner', 'manager', 'attendant']);
   const navigate = useNavigate();
   const { nozzleId } = useParams();
   const { toast } = useToast();

--- a/src/pages/dashboard/NewStationPage.tsx
+++ b/src/pages/dashboard/NewStationPage.tsx
@@ -10,8 +10,10 @@ import { useToast } from '@/hooks/use-toast';
 import { StationForm } from '@/components/stations/StationForm';
 import { useCreateStation } from '@/hooks/api/useStations';
 import { navigateBack } from '@/utils/navigation';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function NewStationPage() {
+  useRoleGuard(['owner', 'manager']);
   const navigate = useNavigate();
   const { toast } = useToast();
   const createStation = useCreateStation();

--- a/src/pages/dashboard/NozzlesPage.tsx
+++ b/src/pages/dashboard/NozzlesPage.tsx
@@ -5,6 +5,7 @@
  */
 import { useState, useEffect } from 'react';
 import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
@@ -23,6 +24,7 @@ import { NozzleCard } from '@/components/nozzles/NozzleCard';
 import { navigateBack } from '@/utils/navigation';
 
 export default function NozzlesPage() {
+  useRoleGuard(['owner', 'manager']);
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();

--- a/src/pages/dashboard/PumpDetailPage.tsx
+++ b/src/pages/dashboard/PumpDetailPage.tsx
@@ -5,6 +5,7 @@
  * @see docs/journeys/MANAGER.md - Manager journey for pump management
  */
 import { useParams, Link } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -19,6 +20,7 @@ import { usePump } from '@/hooks/api/usePumps';
 import { useNozzles } from '@/hooks/api/useNozzles';
 
 export default function PumpDetailPage() {
+  useRoleGuard(['owner', 'manager']);
   // Get pump ID from URL params
   const { pumpId } = useParams<{ pumpId: string }>();
   

--- a/src/pages/dashboard/PumpsPage.tsx
+++ b/src/pages/dashboard/PumpsPage.tsx
@@ -5,6 +5,7 @@
  * Updated layout for mobile-friendliness – 2025-07-03
  */
 import { useState, useEffect } from 'react';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { useParams, useLocation, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -24,6 +25,7 @@ import { useStations, useStation } from '@/hooks/api/useStations';
 import { navigateBack } from '@/utils/navigation';
 
 export default function PumpsPage() {
+  useRoleGuard(['owner', 'manager']);
   const { stationId } = useParams<{ stationId: string }>();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
   const [selectedStationId, setSelectedStationId] = useState(stationId || '');

--- a/src/pages/dashboard/ReadingsPage.tsx
+++ b/src/pages/dashboard/ReadingsPage.tsx
@@ -10,11 +10,13 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Gauge, Clock, AlertTriangle, CheckCircle, Plus, FileText, Eye, Edit, Loader2 } from 'lucide-react';
 import { useNavigate, Link } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { PageHeader } from '@/components/ui/page-header';
 import { useReadings } from '@/hooks/api/useReadings';
 import { useFeatureFlags } from '@/hooks/useFeatureFlags';
 
 export default function ReadingsPage() {
+  useRoleGuard(['owner', 'manager', 'attendant']);
   const navigate = useNavigate();
   const { data: features } = useFeatureFlags();
   const [filter, setFilter] = useState<'all' | 'pending' | 'completed' | 'discrepancy'>('all');

--- a/src/pages/dashboard/ReconciliationPage.tsx
+++ b/src/pages/dashboard/ReconciliationPage.tsx
@@ -10,8 +10,10 @@ import { ReconciliationForm } from '@/components/reconciliation/ReconciliationFo
 import { useDailyReadingsSummary } from '@/hooks/useReconciliation';
 import { useStations } from '@/hooks/useStations';
 import { format } from 'date-fns';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function ReconciliationPage() {
+  useRoleGuard(['owner', 'manager']);
   const [selectedStationId, setSelectedStationId] = useState<string>('');
   const [selectedDate, setSelectedDate] = useState<string>(format(new Date(), 'yyyy-MM-dd'));
 

--- a/src/pages/dashboard/ReportsPage.tsx
+++ b/src/pages/dashboard/ReportsPage.tsx
@@ -10,6 +10,7 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useForm } from 'react-hook-form';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { 
   FileSpreadsheet, 
   Download, 
@@ -27,6 +28,7 @@ import { useToast } from '@/hooks/use-toast';
 import { format } from 'date-fns';
 
 export default function ReportsPage() {
+  useRoleGuard(['owner', 'manager']);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [isDialogOpen, setIsDialogOpen] = useState(false);
   const { toast } = useToast();

--- a/src/pages/dashboard/SalesPage.tsx
+++ b/src/pages/dashboard/SalesPage.tsx
@@ -10,8 +10,10 @@ import { DollarSign, TrendingUp, CreditCard, Users, Download, Filter } from 'luc
 import { Button } from '@/components/ui/button';
 import { DateRange } from 'react-day-picker';
 import { formatCurrency, formatVolume, formatSafeNumber } from '@/utils/formatters';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function SalesPage() {
+  useRoleGuard(['owner', 'manager']);
   const [selectedStation, setSelectedStation] = useState<string | undefined>();
   const [dateRange, setDateRange] = useState<DateRange | undefined>();
   

--- a/src/pages/dashboard/StationDetailPage.tsx
+++ b/src/pages/dashboard/StationDetailPage.tsx
@@ -5,6 +5,7 @@
  * @see docs/journeys/OWNER.md - Owner journey for station management
  */
 import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -25,6 +26,7 @@ import { useStation, useStationMetrics, useStationPerformance, useStationEfficie
 import { usePumps } from '@/hooks/api/usePumps';
 
 export default function StationDetailPage() {
+  useRoleGuard(['owner', 'manager']);
   const { stationId } = useParams<{ stationId: string }>();
   const navigate = useNavigate();
   const { data: station, isLoading, error } = useStation(stationId!);

--- a/src/pages/dashboard/StationDetailsPage.tsx
+++ b/src/pages/dashboard/StationDetailsPage.tsx
@@ -9,8 +9,10 @@ import { ArrowLeft, Edit, Trash2, Fuel, Settings, Plus } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { ErrorFallback } from '@/components/common/ErrorFallback';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function StationDetailsPage() {
+  useRoleGuard(['owner', 'manager']);
   const { stationId } = useParams<{ stationId: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();

--- a/src/pages/dashboard/StationsPage.tsx
+++ b/src/pages/dashboard/StationsPage.tsx
@@ -14,7 +14,7 @@ import { useStations } from '@/hooks/api/useStations';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function StationsPage() {
-  useRoleGuard(['owner']);
+  useRoleGuard(['owner', 'manager']);
   const [searchTerm, setSearchTerm] = useState('');
   const { data: stations = [], isLoading, error } = useStations();
 

--- a/src/pages/dashboard/SummaryPage.tsx
+++ b/src/pages/dashboard/SummaryPage.tsx
@@ -15,6 +15,7 @@ import { ProfitMetricsCard } from '@/components/dashboard/ProfitMetricsCard';
 import { TopCreditorsTable } from '@/components/dashboard/TopCreditorsTable';
 import { StationMetricsCard } from '@/components/dashboard/StationMetricsCard';
 import { StationMetricsList } from '@/components/dashboard/StationMetricsList';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 // Filters
 import { SearchableStationSelector } from '@/components/filters/SearchableStationSelector';
@@ -26,6 +27,7 @@ interface DashboardFilters {
 }
 
 export default function SummaryPage() {
+  useRoleGuard(['owner', 'manager']);
   const { user } = useAuth();
   const [filters, setFilters] = useState<DashboardFilters>({});
   const [isRefreshing, setIsRefreshing] = useState(false);

--- a/src/pages/dashboard/UsersPage.tsx
+++ b/src/pages/dashboard/UsersPage.tsx
@@ -16,8 +16,10 @@ import { UserForm } from '@/components/users/UserForm';
 import { ResetPasswordForm } from '@/components/users/ResetPasswordForm';
 import { useUsers, useCreateUser, useUpdateUser, useDeleteUser, useResetPassword } from '@/hooks/api/useUsers';
 import { User, CreateUserRequest, UpdateUserRequest, ResetPasswordRequest } from '@/api/services/usersService';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function UsersPage() {
+  useRoleGuard(['owner']);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [isResetPasswordDialogOpen, setIsResetPasswordDialogOpen] = useState(false);

--- a/src/pages/superadmin/AnalyticsPage.tsx
+++ b/src/pages/superadmin/AnalyticsPage.tsx
@@ -10,8 +10,10 @@ import { RefreshCw } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
 import { useSystemHealth } from '@/hooks/useSystemHealth';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function AnalyticsPage() {
+  useRoleGuard(['superadmin']);
   const { data: analytics, isLoading, error, refetch, isRefetching } = useQuery({
     queryKey: ['superadmin-analytics'],
     queryFn: superadminApi.getSummary,

--- a/src/pages/superadmin/CreateTenantPage.tsx
+++ b/src/pages/superadmin/CreateTenantPage.tsx
@@ -8,11 +8,13 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ArrowLeft, Building2 } from 'lucide-react';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { superadminApi } from '@/api/superadmin';
 import { CreateTenantRequest } from '@/api/api-contract';
 import { useToast } from '@/hooks/use-toast';
 
 export default function CreateTenantPage() {
+  useRoleGuard(['superadmin']);
   const navigate = useNavigate();
   const { toast } = useToast();
   const queryClient = useQueryClient();

--- a/src/pages/superadmin/OverviewPage.tsx
+++ b/src/pages/superadmin/OverviewPage.tsx
@@ -8,10 +8,12 @@ import { superadminApi, SuperAdminSummary } from '@/api/superadmin';
 import { EnhancedMetricsCard } from '@/components/ui/enhanced-metrics-card';
 import { Badge } from '@/components/ui/badge';
 import { Progress } from '@/components/ui/progress';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { formatDate } from '@/utils/formatters';
 import { useNavigate } from 'react-router-dom';
 
 export default function SuperAdminOverviewPage() {
+  useRoleGuard(['superadmin']);
   const navigate = useNavigate();
   const { toast } = useToast();
   

--- a/src/pages/superadmin/PlansPage.tsx
+++ b/src/pages/superadmin/PlansPage.tsx
@@ -11,8 +11,10 @@ import { Plan } from '@/api/api-contract';
 import { useToast } from '@/hooks/use-toast';
 import { PlanForm } from '@/components/admin/PlanForm';
 import { formatCurrency } from '@/utils/formatters';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function PlansPage() {
+  useRoleGuard(['superadmin']);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
   const [editingPlan, setEditingPlan] = useState<Plan | null>(null);

--- a/src/pages/superadmin/TenantDetailsPage.tsx
+++ b/src/pages/superadmin/TenantDetailsPage.tsx
@@ -6,8 +6,10 @@ import { ArrowLeft, Loader2, AlertCircle, RefreshCw } from 'lucide-react';
 import { TenantHierarchy } from '@/components/admin/TenantHierarchy';
 import { useTenantDetails } from '@/hooks/useTenantDetails';
 import { DashboardErrorBoundary } from '@/components/dashboard/DashboardErrorBoundary';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function TenantDetailsPage() {
+  useRoleGuard(['superadmin']);
   const { tenantId } = useParams<{ tenantId: string }>();
   const navigate = useNavigate();
   

--- a/src/pages/superadmin/TenantSettingsPage.tsx
+++ b/src/pages/superadmin/TenantSettingsPage.tsx
@@ -10,6 +10,7 @@ import { Switch } from '@/components/ui/switch';
 import { Badge } from '@/components/ui/badge';
 import { useToast } from '@/hooks/use-toast';
 import { tenantSettingsApi } from '@/api/tenant-settings';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 interface TenantSetting {
   key: string;
@@ -22,6 +23,7 @@ interface GroupedSettings {
 }
 
 const TenantSettingsPage: React.FC = () => {
+  useRoleGuard(['superadmin']);
   const { tenantId } = useParams<{ tenantId: string }>();
   const navigate = useNavigate();
   const { toast } = useToast();

--- a/src/pages/superadmin/TenantsPage.tsx
+++ b/src/pages/superadmin/TenantsPage.tsx
@@ -8,6 +8,7 @@ import { Building2, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { tenantsApi } from '@/api/tenants';
 import { CreateTenantRequest } from '@/api/api-contract';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { superadminApi } from '@/api/superadmin';
 import { useToast } from '@/hooks/use-toast';
 import { SuperAdminErrorBoundary } from '@/components/admin/SuperAdminErrorBoundary';
@@ -15,6 +16,7 @@ import { TenantForm } from '@/components/admin/TenantForm';
 import { TenantCard } from '@/components/admin/TenantCard';
 
 export default function SuperAdminTenantsPage() {
+  useRoleGuard(['superadmin']);
   const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
   const navigate = useNavigate();
   

--- a/src/pages/superadmin/UsersPage.tsx
+++ b/src/pages/superadmin/UsersPage.tsx
@@ -27,8 +27,10 @@ import { superadminApi } from '@/api/superadmin';
 import { CreateSuperAdminRequest, AdminUser } from '@/api/api-contract';
 import { SuperAdminUserForm } from '@/components/users/SuperAdminUserForm';
 import { ResetPasswordForm } from '@/components/users/ResetPasswordForm';
+import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function UsersPage() {
+  useRoleGuard(['superadmin']);
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [showResetPasswordForm, setShowResetPasswordForm] = useState(false);
   const [selectedUser, setSelectedUser] = useState<AdminUser | null>(null);


### PR DESCRIPTION
## Summary
- restrict page access using `useRoleGuard` for dashboard and superadmin routes
- ensure attendants can't open owner/manager pages directly

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6867aea5972c8320935b2a11ed0a09a5