### PR TITLE
Add inventory hooks and update inventory page

### DIFF
--- a/src/api/api-contract.ts
+++ b/src/api/api-contract.ts
@@ -580,6 +580,23 @@ export interface FuelInventorySummary {
   totalCurrentStock: number;
 }
 
+export interface InventoryItem {
+  id: string;
+  stationId: string;
+  stationName: string;
+  fuelType: 'petrol' | 'diesel' | 'premium';
+  currentStock: number;
+  lowStockThreshold: number;
+  lastUpdated: string;
+  stockStatus?: 'normal' | 'low' | 'critical' | 'overstocked';
+}
+
+export interface InventoryUpdateRequest {
+  stationId: string;
+  fuelType: 'petrol' | 'diesel' | 'premium';
+  newStock: number;
+}
+
 export interface FuelDelivery {
   id: string;
   stationId: string;

--- a/src/api/inventory.ts
+++ b/src/api/inventory.ts
@@ -1,0 +1,29 @@
+import { apiClient, extractApiArray, extractApiData } from './client';
+import type { InventoryItem, Alert, InventoryUpdateRequest } from './api-contract';
+
+export const inventoryApi = {
+  getInventory: async (): Promise<InventoryItem[]> => {
+    try {
+      const response = await apiClient.get('/inventory');
+      return extractApiArray<InventoryItem>(response, 'data');
+    } catch (error) {
+      console.error('Error fetching inventory:', error);
+      return [];
+    }
+  },
+
+  getInventoryAlerts: async (): Promise<Alert[]> => {
+    try {
+      const response = await apiClient.get('/inventory/alerts');
+      return extractApiArray<Alert>(response, 'data');
+    } catch (error) {
+      console.error('Error fetching inventory alerts:', error);
+      return [];
+    }
+  },
+
+  updateInventory: async (data: InventoryUpdateRequest) => {
+    const response = await apiClient.post('/inventory/update', data);
+    return extractApiData<{ status: string }>(response);
+  }
+};

--- a/src/components/fuel-deliveries/DeliveryTable.tsx
+++ b/src/components/fuel-deliveries/DeliveryTable.tsx
@@ -2,8 +2,10 @@
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { FuelDelivery } from '@/api/fuel-deliveries';
+import { useInventoryUpdate } from '@/hooks/useInventory';
 import { format } from 'date-fns';
 
 interface DeliveryTableProps {
@@ -12,6 +14,16 @@ interface DeliveryTableProps {
 }
 
 export function DeliveryTable({ deliveries, isLoading }: DeliveryTableProps) {
+  const updateInventory = useInventoryUpdate();
+
+  const handleConfirm = (delivery: FuelDelivery) => {
+    updateInventory.mutate({
+      stationId: delivery.stationId,
+      fuelType: delivery.fuelType,
+      newStock: delivery.quantity
+    });
+  };
+
   if (isLoading) {
     return (
       <Card>
@@ -47,6 +59,7 @@ export function DeliveryTable({ deliveries, isLoading }: DeliveryTableProps) {
                 <TableHead>Delivery Date</TableHead>
                 <TableHead>Delivered By</TableHead>
                 <TableHead>Created At</TableHead>
+                <TableHead>Confirm</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -62,6 +75,15 @@ export function DeliveryTable({ deliveries, isLoading }: DeliveryTableProps) {
                   <TableCell>{format(new Date(delivery.deliveryDate), 'MMM dd, yyyy')}</TableCell>
                   <TableCell>{delivery.deliveredBy || '-'}</TableCell>
                   <TableCell>{format(new Date(delivery.createdAt), 'MMM dd, yyyy HH:mm')}</TableCell>
+                  <TableCell>
+                    {delivery.status === 'confirmed' ? (
+                      <Badge variant="secondary">Confirmed</Badge>
+                    ) : (
+                      <Button size="sm" onClick={() => handleConfirm(delivery)} disabled={updateInventory.isPending}>
+                        Confirm
+                      </Button>
+                    )}
+                  </TableCell>
                 </TableRow>
               ))}
             </TableBody>

--- a/src/hooks/useInventory.ts
+++ b/src/hooks/useInventory.ts
@@ -1,0 +1,39 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { inventoryApi } from '@/api/inventory';
+import type { InventoryUpdateRequest } from '@/api/api-contract';
+import { useToast } from './use-toast';
+
+export const useInventory = () => {
+  return useQuery({
+    queryKey: ['inventory'],
+    queryFn: () => inventoryApi.getInventory(),
+  });
+};
+
+export const useInventoryAlerts = () => {
+  return useQuery({
+    queryKey: ['inventory', 'alerts'],
+    queryFn: () => inventoryApi.getInventoryAlerts(),
+  });
+};
+
+export const useInventoryUpdate = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: (data: InventoryUpdateRequest) => inventoryApi.updateInventory(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['inventory'] });
+      queryClient.invalidateQueries({ queryKey: ['inventory', 'alerts'] });
+      toast({ title: 'Inventory Updated', description: 'Inventory counts updated successfully.' });
+    },
+    onError: (error: any) => {
+      toast({
+        title: 'Error',
+        description: error.response?.data?.message || 'Failed to update inventory',
+        variant: 'destructive',
+      });
+    },
+  });
+};

--- a/src/pages/dashboard/InventoryPage.tsx
+++ b/src/pages/dashboard/InventoryPage.tsx
@@ -1,11 +1,16 @@
 
-import { useFuelInventory } from '@/hooks/useFuelInventory';
+import { useInventory } from '@/hooks/useInventory';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AlertTriangle } from 'lucide-react';
 import { InventoryTable } from '@/components/fuel-deliveries/InventoryTable';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function InventoryPage() {
   useRoleGuard(['owner', 'manager']);
-  const { data: inventory = [], isLoading } = useFuelInventory();
+  const { data: inventory = [], isLoading } = useInventory();
+  const lowStock = inventory.filter(
+    (item: any) => item.currentStock < item.lowStockThreshold
+  );
 
   return (
     <div className="space-y-6">
@@ -13,6 +18,22 @@ export default function InventoryPage() {
         <h1 className="text-3xl font-bold tracking-tight">Fuel Inventory</h1>
         <p className="text-muted-foreground">Monitor current fuel stock levels across all stations</p>
       </div>
+
+      {lowStock.length > 0 && (
+        <Card className="bg-yellow-50 border-yellow-300">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-yellow-800">
+              <AlertTriangle className="h-4 w-4" />
+              Low Stock Warning
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-yellow-800">
+              {lowStock.length} fuel type(s) are below the low stock threshold.
+            </p>
+          </CardContent>
+        </Card>
+      )}
 
       <InventoryTable inventory={inventory} isLoading={isLoading} />
     </div>


### PR DESCRIPTION
## Summary
- add InventoryItem and InventoryUpdateRequest types
- implement inventory API helper
- create `useInventory`, `useInventoryAlerts`, and `useInventoryUpdate` hooks
- warn when fuel is below threshold on InventoryPage
- add delivery confirmation button that updates inventory

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6867bb9378e48320b32c3590fa39b048