### PR TITLE
Add shared breadcrumbs component

### DIFF
--- a/src/components/common/Breadcrumbs.tsx
+++ b/src/components/common/Breadcrumbs.tsx
@@ -1,0 +1,92 @@
+import { Link, useLocation, useParams } from 'react-router-dom';
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import { useStation } from '@/hooks/api/useStations';
+import { usePump } from '@/hooks/api/usePumps';
+import { useNozzle } from '@/hooks/api/useNozzles';
+
+/**
+ * Shared breadcrumbs component that builds a trail based on the current route
+ * and parent entity names (station, pump, nozzle).
+ */
+export function Breadcrumbs() {
+  const location = useLocation();
+  const { stationId, pumpId, nozzleId } = useParams<{
+    stationId?: string;
+    pumpId?: string;
+    nozzleId?: string;
+  }>();
+
+  const { data: station } = useStation(stationId ?? '');
+  const { data: pump } = usePump(pumpId ?? '');
+  const { data: nozzle } = useNozzle(nozzleId ?? '');
+
+  const items: { label: string; href: string }[] = [
+    { label: 'Dashboard', href: '/dashboard' },
+  ];
+
+  if (stationId) {
+    items.push({ label: 'Stations', href: '/dashboard/stations' });
+    items.push({
+      label: station?.name || 'Station',
+      href: `/dashboard/stations/${stationId}`,
+    });
+  }
+
+  if (pumpId) {
+    const base = stationId
+      ? `/dashboard/stations/${stationId}/pumps`
+      : '/dashboard/pumps';
+    items.push({ label: 'Pumps', href: base });
+    items.push({
+      label: pump?.name || 'Pump',
+      href: `${base}/${pumpId}`,
+    });
+  }
+
+  if (nozzleId) {
+    const base = stationId && pumpId
+      ? `/dashboard/stations/${stationId}/pumps/${pumpId}/nozzles`
+      : pumpId
+      ? `/dashboard/pumps/${pumpId}/nozzles`
+      : '/dashboard/nozzles';
+    items.push({ label: 'Nozzles', href: base });
+    items.push({
+      label: nozzle ? `Nozzle ${nozzle.nozzleNumber}` : 'Nozzle',
+      href: `${base}/${nozzleId}`,
+    });
+  }
+
+  if (location.pathname.endsWith('/new')) {
+    items.push({ label: 'New', href: location.pathname });
+  } else if (location.pathname.endsWith('/edit')) {
+    items.push({ label: 'Edit', href: location.pathname });
+  }
+
+  const lastIndex = items.length - 1;
+
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        {items.map((item, idx) => (
+          <BreadcrumbItem key={idx}>
+            {idx === lastIndex ? (
+              <BreadcrumbPage>{item.label}</BreadcrumbPage>
+            ) : (
+              <BreadcrumbLink asChild>
+                <Link to={item.href}>{item.label}</Link>
+              </BreadcrumbLink>
+            )}
+            {idx < lastIndex && <BreadcrumbSeparator />}
+          </BreadcrumbItem>
+        ))}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/src/pages/dashboard/NewStationPage.tsx
+++ b/src/pages/dashboard/NewStationPage.tsx
@@ -4,12 +4,12 @@
  * @description Page for creating new stations with improved form layout
  */
 import { useNavigate } from 'react-router-dom';
+import { Breadcrumbs } from '@/components/common/Breadcrumbs';
 import { Button } from '@/components/ui/button';
 import { ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { StationForm } from '@/components/stations/StationForm';
 import { useCreateStation } from '@/hooks/api/useStations';
-import { navigateBack } from '@/utils/navigation';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 
 export default function NewStationPage() {
@@ -37,12 +37,13 @@ export default function NewStationPage() {
 
   return (
     <div className="space-y-6">
+      <Breadcrumbs />
       {/* Header */}
       <div className="flex items-center gap-2">
-        <Button 
-          variant="outline" 
-          size="sm" 
-          onClick={() => navigateBack(navigate, '/dashboard/stations')}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => navigate('/dashboard/stations')}
         >
           <ArrowLeft className="mr-2 h-4 w-4" />
           Back to Stations

--- a/src/pages/dashboard/NozzlesPage.tsx
+++ b/src/pages/dashboard/NozzlesPage.tsx
@@ -21,7 +21,7 @@ import { useNozzles, useDeleteNozzle } from '@/hooks/api/useNozzles';
 import { useStations } from '@/hooks/api/useStations';
 import { useToast } from '@/hooks/use-toast';
 import { NozzleCard } from '@/components/nozzles/NozzleCard';
-import { navigateBack } from '@/utils/navigation';
+import { Breadcrumbs } from '@/components/common/Breadcrumbs';
 
 export default function NozzlesPage() {
   useRoleGuard(['owner', 'manager']);
@@ -97,7 +97,7 @@ export default function NozzlesPage() {
     if (selectedStationId) {
       navigate(`/dashboard/pumps?stationId=${selectedStationId}`);
     } else {
-      navigateBack(navigate, '/dashboard/pumps');
+      navigate('/dashboard/pumps');
     }
   };
 
@@ -266,19 +266,13 @@ export default function NozzlesPage() {
   if (nozzles.length === 0 && !nozzlesLoading) {
     return (
       <div className="space-y-4 sm:space-y-6 p-4 sm:p-6">
-        {/* Header with improved mobile layout */}
+        <Breadcrumbs />
         <div className="flex flex-col gap-4">
-          <div className="flex items-center gap-3">
-            <Button variant="outline" size="sm" onClick={handleBack}>
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              <span className="hidden sm:inline">Back</span>
-            </Button>
-            <div className="min-w-0 flex-1">
-              <h1 className="text-xl sm:text-2xl font-bold tracking-tight">Nozzles</h1>
-              <p className="text-muted-foreground text-sm truncate">
-                Pump: {pump.name} {pump.serialNumber ? `| Serial: ${pump.serialNumber}` : ''}
-              </p>
-            </div>
+          <div className="min-w-0">
+            <h1 className="text-xl sm:text-2xl font-bold tracking-tight">Nozzles</h1>
+            <p className="text-muted-foreground text-sm truncate">
+              Pump: {pump.name} {pump.serialNumber ? `| Serial: ${pump.serialNumber}` : ''}
+            </p>
           </div>
           <Button onClick={handleCreateNozzle} className="w-full sm:w-auto sm:self-start">
             <Plus className="mr-2 h-4 w-4" />
@@ -303,35 +297,24 @@ export default function NozzlesPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6 p-4 sm:p-6">
-      {/* Header with improved mobile layout */}
+      <Breadcrumbs />
       <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3 min-w-0">
-          <Button variant="outline" size="sm" onClick={handleBack}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            <span className="hidden sm:inline">Back</span>
-          </Button>
-          <div className="min-w-0 flex-1">
-            <h1 className="text-xl sm:text-2xl font-bold tracking-tight">Nozzles</h1>
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 mt-1">
-              <p className="text-muted-foreground text-sm hidden sm:block">
-                Pump: 
-              </p>
-              <Select 
-                value={selectedPumpId} 
-                onValueChange={handlePumpChange}
-              >
-                <SelectTrigger className="w-full sm:w-[200px] h-8 text-xs sm:text-sm">
-                  <SelectValue placeholder="Select pump" />
-                </SelectTrigger>
-                <SelectContent>
-                  {pumps.map((p) => (
-                    <SelectItem key={p.id} value={p.id}>
-                      {p.name} {p.serialNumber ? `(${p.serialNumber})` : ''}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-xl sm:text-2xl font-bold tracking-tight">Nozzles</h1>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 mt-1">
+            <p className="text-muted-foreground text-sm hidden sm:block">Pump:</p>
+            <Select value={selectedPumpId} onValueChange={handlePumpChange}>
+              <SelectTrigger className="w-full sm:w-[200px] h-8 text-xs sm:text-sm">
+                <SelectValue placeholder="Select pump" />
+              </SelectTrigger>
+              <SelectContent>
+                {pumps.map((p) => (
+                  <SelectItem key={p.id} value={p.id}>
+                    {p.name} {p.serialNumber ? `(${p.serialNumber})` : ''}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
         <Button onClick={handleCreateNozzle} className="w-full sm:w-auto sm:self-start">

--- a/src/pages/dashboard/PumpDetailPage.tsx
+++ b/src/pages/dashboard/PumpDetailPage.tsx
@@ -5,6 +5,7 @@
  * @see docs/journeys/MANAGER.md - Manager journey for pump management
  */
 import { useParams, Link } from 'react-router-dom';
+import { Breadcrumbs } from '@/components/common/Breadcrumbs';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
@@ -68,21 +69,11 @@ export default function PumpDetailPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header with back button */}
+      <Breadcrumbs />
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" asChild>
-            <Link to="/dashboard/pumps">
-              <ArrowLeft className="mr-2 h-4 w-4" />
-              Back
-            </Link>
-          </Button>
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">{pump.name}</h1>
-            <p className="text-muted-foreground">
-              Serial: {pump.serialNumber}
-            </p>
-          </div>
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">{pump.name}</h1>
+          <p className="text-muted-foreground">Serial: {pump.serialNumber}</p>
         </div>
         <Badge 
           variant={pump.status === 'active' ? 'default' : 'secondary'}

--- a/src/pages/dashboard/PumpsPage.tsx
+++ b/src/pages/dashboard/PumpsPage.tsx
@@ -16,13 +16,13 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useForm } from 'react-hook-form';
-import { Plus, Fuel, Settings, Activity, Building2, Loader2, ArrowLeft } from 'lucide-react';
+import { Plus, Fuel, Settings, Activity, Building2, Loader2 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { PumpCard } from '@/components/pumps/PumpCard';
 import { MobileStatsCard } from '@/components/dashboard/MobileStatsCard';
 import { usePumps } from '@/hooks/api/usePumps';
 import { useStations, useStation } from '@/hooks/api/useStations';
-import { navigateBack } from '@/utils/navigation';
+import { Breadcrumbs } from '@/components/common/Breadcrumbs';
 
 export default function PumpsPage() {
   useRoleGuard(['owner', 'manager']);
@@ -135,7 +135,7 @@ export default function PumpsPage() {
 
   // Handle back to stations navigation
   const handleBackToStations = () => {
-    navigateBack(navigate, '/dashboard/stations');
+    navigate('/dashboard/stations');
   };
 
   const isLoading = stationsLoading || pumpsLoading;
@@ -226,36 +226,24 @@ export default function PumpsPage() {
 
   return (
     <div className="space-y-4 sm:space-y-6 p-4 sm:p-6">
-      {/* Improved header layout for mobile */}
+      <Breadcrumbs />
       <div className="flex flex-col gap-4">
-        <div className="flex items-center gap-3 min-w-0">
-          <Button variant="outline" size="sm" onClick={handleBackToStations}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            <span className="hidden sm:inline">Back to Stations</span>
-            <span className="sm:hidden">Back</span>
-          </Button>
-          <div className="min-w-0 flex-1">
-            <h1 className="text-xl sm:text-2xl md:text-3xl font-bold tracking-tight">Pumps</h1>
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 mt-1">
-              <p className="text-muted-foreground text-sm hidden sm:block">
-                Station: 
-              </p>
-              <Select 
-                value={effectiveStationId} 
-                onValueChange={handleStationChange}
-              >
-                <SelectTrigger className="w-full sm:w-[200px] h-8 text-xs sm:text-sm">
-                  <SelectValue placeholder="Select station" />
-                </SelectTrigger>
-                <SelectContent>
-                  {stations.map((station) => (
-                    <SelectItem key={station.id} value={station.id}>
-                      {station.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+        <div className="min-w-0 flex-1">
+          <h1 className="text-xl sm:text-2xl md:text-3xl font-bold tracking-tight">Pumps</h1>
+          <div className="flex flex-col sm:flex-row sm:items-center gap-2 mt-1">
+            <p className="text-muted-foreground text-sm hidden sm:block">Station:</p>
+            <Select value={effectiveStationId} onValueChange={handleStationChange}>
+              <SelectTrigger className="w-full sm:w-[200px] h-8 text-xs sm:text-sm">
+                <SelectValue placeholder="Select station" />
+              </SelectTrigger>
+              <SelectContent>
+                {stations.map((station) => (
+                  <SelectItem key={station.id} value={station.id}>
+                    {station.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
         </div>
         

--- a/src/pages/dashboard/StationDetailPage.tsx
+++ b/src/pages/dashboard/StationDetailPage.tsx
@@ -5,17 +5,17 @@
  * @see docs/journeys/OWNER.md - Owner journey for station management
  */
 import { useParams, Link, useNavigate } from 'react-router-dom';
+import { Breadcrumbs } from '@/components/common/Breadcrumbs';
 import { useRoleGuard } from '@/hooks/useRoleGuard';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { 
-  Building2, 
-  MapPin, 
-  Fuel, 
-  ArrowLeft, 
-  Settings, 
-  BarChart3, 
+  Building2,
+  MapPin,
+  Fuel,
+  Settings,
+  BarChart3,
   Loader2,
   AlertTriangle,
   Plus,
@@ -56,16 +56,11 @@ export default function StationDetailPage() {
 
   return (
     <div className="space-y-6">
+      <Breadcrumbs />
       <div className="flex items-center justify-between">
-        <div className="flex items-center gap-4">
-          <Button variant="outline" size="sm" onClick={() => navigate('/dashboard/stations')}>
-            <ArrowLeft className="mr-2 h-4 w-4" />
-            Back to Stations
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold">{station.name}</h1>
-            <p className="text-muted-foreground">{station.address}</p>
-          </div>
+        <div>
+          <h1 className="text-3xl font-bold">{station.name}</h1>
+          <p className="text-muted-foreground">{station.address}</p>
         </div>
         <div className="flex gap-2">
           <Button variant="outline">

--- a/src/pages/dashboard/StationDetailsPage.tsx
+++ b/src/pages/dashboard/StationDetailsPage.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { ArrowLeft, Edit, Trash2, Fuel, Settings, Plus } from 'lucide-react';
+import { Breadcrumbs } from '@/components/common/Breadcrumbs';
 import { useToast } from '@/hooks/use-toast';
 import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { ErrorFallback } from '@/components/common/ErrorFallback';
@@ -103,17 +104,11 @@ export default function StationDetailsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
+      <Breadcrumbs />
       <div className="flex items-center justify-between">
-        <div className="flex items-center space-x-4">
-          <Button variant="ghost" size="sm" onClick={() => navigate('/dashboard/stations')}>
-            <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Stations
-          </Button>
-          <div>
-            <h1 className="text-3xl font-bold tracking-tight">{station.name}</h1>
-            <p className="text-muted-foreground">{station.address}</p>
-          </div>
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">{station.name}</h1>
+          <p className="text-muted-foreground">{station.address}</p>
         </div>
         <div className="flex items-center gap-2">
           <Badge 


### PR DESCRIPTION
## Summary
- add `Breadcrumbs` component to build trail from route entities
- update detail pages to use new breadcrumbs and remove custom navigation helpers

## Testing
- `npm test` *(fails: no test script)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867c228d55083208acae2fab75f93a5