### PR TITLE
Improve responsive layouts with window size hook

### DIFF
--- a/src/components/analytics/AnalyticsDashboard.tsx
+++ b/src/components/analytics/AnalyticsDashboard.tsx
@@ -4,12 +4,15 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@
 import { SuperAdminAnalytics } from '@/api/api-contract';
 import { Building2, Users, Gauge, DollarSign, TrendingUp } from 'lucide-react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts';
+import { useWindowSize } from '@/hooks/use-window-size';
 
 interface AnalyticsDashboardProps {
   analytics: SuperAdminAnalytics;
 }
 
 export function AnalyticsDashboard({ analytics }: AnalyticsDashboardProps) {
+  const { width } = useWindowSize();
+  const chartHeight = width < 640 ? 240 : 300;
   return (
     <div className="space-y-6">
       {/* Key Metrics */}
@@ -78,7 +81,7 @@ export function AnalyticsDashboard({ analytics }: AnalyticsDashboardProps) {
             <CardDescription>Tenant signups and revenue over time</CardDescription>
           </CardHeader>
           <CardContent>
-            <ResponsiveContainer width="100%" height={300}>
+            <ResponsiveContainer width="100%" height={chartHeight}>
               <BarChart data={analytics.monthlyGrowth}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="month" />

--- a/src/components/dashboard/PaymentMethodChart.tsx
+++ b/src/components/dashboard/PaymentMethodChart.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '@/components/ui/chart';
 import { PieChart, Pie, Cell, ResponsiveContainer } from 'recharts';
 import { usePaymentMethodBreakdown } from '@/hooks/useDashboard';
+import { useWindowSize } from '@/hooks/use-window-size';
 
 const COLORS = {
   cash: '#22c55e',
@@ -23,6 +24,9 @@ interface PaymentMethodChartProps {
 
 export function PaymentMethodChart({ filters = {} }: PaymentMethodChartProps) {
   const { data: breakdown = [], isLoading } = usePaymentMethodBreakdown(filters);
+  const { width } = useWindowSize();
+
+  const isSmall = width < 640;
 
   if (isLoading) {
     return (
@@ -50,20 +54,23 @@ export function PaymentMethodChart({ filters = {} }: PaymentMethodChartProps) {
     credit: { label: 'Credit', color: COLORS.credit },
   };
 
+  const chartHeight = isSmall ? 200 : 300;
+  const outerRadius = isSmall ? 80 : 100;
+
   return (
     <Card className="bg-gradient-to-br from-white to-blue-50 border-blue-200">
       <CardHeader>
         <CardTitle className="text-blue-700">Payment Method Breakdown</CardTitle>
       </CardHeader>
       <CardContent>
-        <ChartContainer config={chartConfig} className="h-[300px]">
+        <ChartContainer config={chartConfig} style={{ height: chartHeight }}>
           <ResponsiveContainer width="100%" height="100%">
             <PieChart>
               <Pie
                 data={chartData}
                 cx="50%"
                 cy="50%"
-                outerRadius={100}
+                outerRadius={outerRadius}
                 dataKey="value"
                 label={({ name, percentage }) => `${name}: ${percentage}%`}
               >

--- a/src/components/dashboard/TopCreditorsTable.tsx
+++ b/src/components/dashboard/TopCreditorsTable.tsx
@@ -55,6 +55,7 @@ export function TopCreditorsTable({ filters = {} }: TopCreditorsTableProps) {
         <CardTitle className="text-orange-700">Top Creditors by Outstanding</CardTitle>
       </CardHeader>
       <CardContent>
+        <div className="overflow-x-auto">
         <Table>
           <TableHeader>
             <TableRow>
@@ -100,6 +101,7 @@ export function TopCreditorsTable({ filters = {} }: TopCreditorsTableProps) {
             })}
           </TableBody>
         </Table>
+        </div>
       </CardContent>
     </Card>
   );

--- a/src/hooks/use-window-size.ts
+++ b/src/hooks/use-window-size.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+export interface WindowSize {
+  width: number;
+  height: number;
+}
+
+export function useWindowSize(): WindowSize {
+  const [size, setSize] = useState<WindowSize>({
+    width: window.innerWidth,
+    height: window.innerHeight,
+  });
+
+  useEffect(() => {
+    const handleResize = () => {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return size;
+}


### PR DESCRIPTION
## Summary
- add a `useWindowSize` hook
- tune PaymentMethodChart for small screens
- resize charts in AnalyticsDashboard responsively
- wrap TopCreditorsTable in an overflow container

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c48f31288320964ff19eebf695a0