### PR TITLE
Fix hooks to use data responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,4 @@ All notable changes to this project will be documented in this file.
 - Merged fuel inventory APIs into `src/api/inventory.ts`
 - Removed `src/api/services/stationsService.ts` and `src/api/fuel-inventory.ts`
 - Updated hooks and context imports to use unified services
+### [fix] Align response extraction with OpenAPI data keys

--- a/fuelsync/docs/IMPLEMENTATION_INDEX.md
+++ b/fuelsync/docs/IMPLEMENTATION_INDEX.md
@@ -221,3 +221,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.55 | Dashboard station metrics endpoint | ✅ Done | `src/services/station.service.ts`, `src/controllers/dashboard.controller.ts`, `src/routes/dashboard.route.ts`, `docs/openapi.yaml` | `PHASE_2_SUMMARY.md#step-2.55` |
 | fix | 2025-12-01 | Alert parameter naming alignment | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml` | `docs/STEP_fix_20251201.md` |
 | 2     | 2.56 | Backend analytics and inventory completion | ✅ Done | `src/services/analytics.service.ts`, `src/services/fuelInventory.service.ts`, `src/services/tenant.service.ts`, `src/controllers`, `src/routes`, `docs/openapi.yaml` | `docs/STEP_2_56_COMMAND.md` |
+| fix | 2025-12-02 | Frontend hooks OpenAPI alignment | ✅ Done | src/api/* | docs/STEP_fix_20251202.md |

--- a/fuelsync/docs/PHASE_2_SUMMARY.md
+++ b/fuelsync/docs/PHASE_2_SUMMARY.md
@@ -1234,3 +1234,11 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Fuel inventory uses delivery and reading data for tank levels.
 * Auth responses now return tenant name and fuel price list includes station name.
 * Marked testing endpoints as internal in API docs.
+
+### 🛠️ Fix 2025-12-02 – Frontend hooks OpenAPI alignment
+**Status:** ✅ Done
+**Files:** `src/api/*`, `CHANGELOG.md`, `docs/STEP_fix_20251202.md`
+
+**Overview:**
+* API services now read from the `data` field of responses.
+* Legacy keys like `stations` or `inventory` are no longer referenced.

--- a/fuelsync/docs/STEP_fix_20251202.md
+++ b/fuelsync/docs/STEP_fix_20251202.md
@@ -1,0 +1,15 @@
+# STEP_fix_20251202.md — Align frontend hooks with OpenAPI data keys
+
+## Project Context Summary
+Backend responses follow the `{ success, data }` structure per `docs/openapi.yaml`. Some
+API hooks still referenced nested keys like `stations` or `inventory`, relying on fallback
+logic.
+
+## What Was Done Now
+- Updated all API services to extract results exclusively from the `data` field.
+- Removed legacy fallback keys in stations, inventory and related APIs.
+- Simplified pumps and sales services to expect OpenAPI responses.
+
+## Required Documentation Updates
+- Added changelog entry under Fixes.
+- Recorded this fix in `IMPLEMENTATION_INDEX.md` and `PHASE_2_SUMMARY.md`.

--- a/src/api/alerts.ts
+++ b/src/api/alerts.ts
@@ -10,7 +10,7 @@ export const alertsApi = {
       if (params?.unreadOnly) searchParams.append('unreadOnly', 'true');
       
       const response = await apiClient.get(`/alerts?${searchParams.toString()}`);
-      return extractApiArray<Alert>(response, 'alerts');
+      return extractApiArray<Alert>(response);
     } catch (error) {
       console.error('Error fetching alerts:', error);
       return [];

--- a/src/api/attendant.ts
+++ b/src/api/attendant.ts
@@ -22,7 +22,7 @@ export const attendantApi = {
   getAssignedStations: async (): Promise<AttendantStation[]> => {
     devLog('Fetching assigned stations for attendant');
     const response = await apiClient.get('/attendant/stations');
-    return extractApiArray<AttendantStation>(response, 'stations');
+    return extractApiArray<AttendantStation>(response);
   },
 
   // Get assigned pumps for current attendant
@@ -30,7 +30,7 @@ export const attendantApi = {
     devLog('Fetching assigned pumps for attendant', { stationId });
     const params = stationId ? `?stationId=${stationId}` : '';
     const response = await apiClient.get(`/attendant/pumps${params}`);
-    return extractApiArray<AttendantPump>(response, 'pumps');
+    return extractApiArray<AttendantPump>(response);
   },
 
   // Get assigned nozzles for current attendant
@@ -38,7 +38,7 @@ export const attendantApi = {
     devLog('Fetching assigned nozzles for attendant', { pumpId });
     const params = pumpId ? `?pumpId=${pumpId}` : '';
     const response = await apiClient.get(`/attendant/nozzles${params}`);
-    return extractApiArray<AttendantNozzle>(response, 'nozzles');
+    return extractApiArray<AttendantNozzle>(response);
   },
 
   // Get assigned creditors for current attendant
@@ -46,7 +46,7 @@ export const attendantApi = {
     devLog('Fetching assigned creditors for attendant', { stationId });
     const params = stationId ? `?stationId=${stationId}` : '';
     const response = await apiClient.get(`/attendant/creditors${params}`);
-    return extractApiArray<Creditor>(response, 'creditors');
+    return extractApiArray<Creditor>(response);
   },
 
   // Submit cash report
@@ -66,14 +66,14 @@ export const attendantApi = {
     
     const queryString = params.toString();
     const response = await apiClient.get(`/attendant/cash-reports${queryString ? `?${queryString}` : ''}`);
-    return extractApiArray<CashReport>(response, 'reports');
+    return extractApiArray<CashReport>(response);
   },
 
   // Get system alerts for attendant
   getAlerts: async (): Promise<SystemAlert[]> => {
     devLog('Fetching system alerts for attendant');
     const response = await apiClient.get('/attendant/alerts');
-    return extractApiArray<SystemAlert>(response, 'alerts');
+    return extractApiArray<SystemAlert>(response);
   },
 
   // Acknowledge alert

--- a/src/api/creditors.ts
+++ b/src/api/creditors.ts
@@ -12,7 +12,7 @@ export const creditorsApi = {
   // Get all creditors
   getCreditors: async (): Promise<Creditor[]> => {
     const response = await apiClient.get('/creditors');
-    return extractApiArray<Creditor>(response, 'creditors');
+    return extractApiArray<Creditor>(response);
   },
 
   // Create new creditor

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -27,32 +27,32 @@ export const dashboardApi = {
     const response = await apiClient.get('/dashboard/payment-methods', {
       params: filters
     });
-    return extractApiArray<PaymentMethodBreakdown>(response, 'paymentMethods');
+    return extractApiArray<PaymentMethodBreakdown>(response);
   },
 
   getFuelTypeBreakdown: async (filters: DashboardFilters = {}): Promise<FuelTypeBreakdown[]> => {
     const response = await apiClient.get('/api/v1/dashboard/fuel-breakdown', {
       params: filters
     });
-    return extractApiArray<FuelTypeBreakdown>(response, 'fuelTypes');
+    return extractApiArray<FuelTypeBreakdown>(response);
   },
 
   getTopCreditors: async (limit: number = 5): Promise<TopCreditor[]> => {
     const response = await apiClient.get('/dashboard/top-creditors', {
       params: { limit }
     });
-    return extractApiArray<TopCreditor>(response, 'creditors');
+    return extractApiArray<TopCreditor>(response);
   },
 
   getDailySalesTrend: async (days: number = 7, filters: DashboardFilters = {}): Promise<DailySalesTrend[]> => {
     const response = await apiClient.get('/api/v1/dashboard/sales-trend', {
       params: { days, ...filters }
     });
-    return extractApiArray<DailySalesTrend>(response, 'trends');
+    return extractApiArray<DailySalesTrend>(response);
   },
 
   getStationMetrics: async (): Promise<StationMetric[]> => {
     const response = await apiClient.get('/dashboard/station-metrics');
-    return extractApiArray<StationMetric>(response, 'stations');
+    return extractApiArray<StationMetric>(response);
   },
 };

--- a/src/api/fuel-deliveries.ts
+++ b/src/api/fuel-deliveries.ts
@@ -10,7 +10,7 @@ export const fuelDeliveriesApi = {
       if (stationId) params.append('stationId', stationId);
       
       const response = await apiClient.get(`/fuel-deliveries?${params.toString()}`);
-      return extractApiArray<FuelDelivery>(response, 'deliveries');
+      return extractApiArray<FuelDelivery>(response);
     } catch (error) {
       console.error('Error fetching fuel deliveries:', error);
       return [];
@@ -30,7 +30,7 @@ export const fuelDeliveriesApi = {
       if (stationId) params.append('stationId', stationId);
 
       const response = await apiClient.get(`/fuel-deliveries/inventory?${params.toString()}`);
-      return extractApiArray<FuelInventory>(response, 'inventory');
+      return extractApiArray<FuelInventory>(response);
     } catch (error) {
       console.error('Error fetching deliveries inventory:', error);
       return [];

--- a/src/api/fuel-price-validation.ts
+++ b/src/api/fuel-price-validation.ts
@@ -20,7 +20,7 @@ export const fuelPriceValidationApi = {
   getMissingPrices: async (): Promise<FuelPriceValidation[]> => {
     devLog('Fetching missing fuel prices for all stations');
     const response = await apiClient.get('/fuel-prices/missing');
-    return extractApiArray<FuelPriceValidation>(response, 'validations');
+    return extractApiArray<FuelPriceValidation>(response);
   },
 
   // Check if reading can be created (has valid fuel prices)

--- a/src/api/fuel-prices.ts
+++ b/src/api/fuel-prices.ts
@@ -10,20 +10,7 @@ export const fuelPricesApi = {
       const response = await apiClient.get('/fuel-prices');
       console.log('[FUEL-PRICES-API] Raw response:', response.data);
       
-      // Handle the actual response structure from backend
-      let rawPrices: any[] = [];
-      
-      if (response.data?.data?.prices) {
-        rawPrices = response.data.data.prices;
-      } else if (response.data?.prices) {
-        rawPrices = response.data.prices;
-      } else if (Array.isArray(response.data)) {
-        rawPrices = response.data;
-      } else if (response.data?.data && Array.isArray(response.data.data)) {
-        rawPrices = response.data.data;
-      }
-      
-      console.log('[FUEL-PRICES-API] Raw prices array:', rawPrices);
+      const rawPrices = extractApiArray<any>(response);
       
       // Convert snake_case to camelCase
       const fuelPrices = rawPrices.map((price: any) => ({

--- a/src/api/inventory.ts
+++ b/src/api/inventory.ts
@@ -22,7 +22,7 @@ export const inventoryApi = {
       const response = await apiClient.get(
         `/fuel-inventory${query ? `?${query}` : ''}`
       );
-      return extractApiArray<FuelInventory>(response, 'inventory');
+      return extractApiArray<FuelInventory>(response);
     } catch (error) {
       console.error('Error fetching fuel inventory:', error);
       return [];
@@ -42,7 +42,7 @@ export const inventoryApi = {
   getInventory: async (): Promise<InventoryItem[]> => {
     try {
       const response = await apiClient.get('/inventory');
-      return extractApiArray<InventoryItem>(response, 'data');
+      return extractApiArray<InventoryItem>(response);
     } catch (error) {
       console.error('Error fetching inventory:', error);
       return [];
@@ -52,7 +52,7 @@ export const inventoryApi = {
   getInventoryAlerts: async (): Promise<Alert[]> => {
     try {
       const response = await apiClient.get('/inventory/alerts');
-      return extractApiArray<Alert>(response, 'data');
+      return extractApiArray<Alert>(response);
     } catch (error) {
       console.error('Error fetching inventory alerts:', error);
       return [];

--- a/src/api/pumps.ts
+++ b/src/api/pumps.ts
@@ -5,38 +5,9 @@ export const pumpsApi = {
   // Get pumps for a station
   getPumps: async (stationId: string): Promise<Pump[]> => {
     try {
-      console.log(`[PUMPS-API] Fetching pumps for station: ${stationId}`);
-      
-      // Use the correct API endpoint according to the API spec
       const url = stationId === 'all' ? '/pumps' : `/pumps?stationId=${stationId}`;
-      
-      console.log(`[PUMPS-API] Making request to: ${url}`);
       const response = await apiClient.get(url);
-      
-      // Extract pumps from response using the helper function
-      // Try different possible response formats
-      let pumps: Pump[] = [];
-      
-      if (response.data?.data?.pumps) {
-        // Format: { data: { pumps: [...] } }
-        pumps = response.data.data.pumps;
-      } else if (response.data?.pumps) {
-        // Format: { pumps: [...] }
-        pumps = response.data.pumps;
-      } else if (Array.isArray(response.data)) {
-        // Format: [...]
-        pumps = response.data;
-      } else if (response.data?.data && Array.isArray(response.data.data)) {
-        // Format: { data: [...] }
-        pumps = response.data.data;
-      } else {
-        // Use the helper function as fallback
-        pumps = extractApiArray<Pump>(response, 'pumps');
-      }
-      
-      console.log(`[PUMPS-API] Successfully fetched ${pumps.length} pumps`);
-      
-      return pumps;
+      return extractApiArray<Pump>(response);
     } catch (error) {
       console.error('[PUMPS-API] Error fetching pumps:', error);
       throw error; // Throw error to trigger React Query's retry mechanism

--- a/src/api/readings.ts
+++ b/src/api/readings.ts
@@ -21,7 +21,7 @@ export const readingsApi = {
   getLatestReading: async (nozzleId: string): Promise<NozzleReading | null> => {
     try {
       const response = await apiClient.get(`/nozzle-readings?nozzleId=${nozzleId}`);
-      const readings = extractApiArray<NozzleReading>(response, 'readings');
+      const readings = extractApiArray<NozzleReading>(response);
       
       if (readings.length === 0) return null;
       

--- a/src/api/reconciliation.ts
+++ b/src/api/reconciliation.ts
@@ -12,7 +12,7 @@ export const reconciliationApi = {
   getDailyReadingsSummary: async (stationId: string, date: string): Promise<DailyReadingSummary[]> => {
     try {
       const response = await apiClient.get(`/reconciliation/daily-summary?stationId=${stationId}&date=${date}`);
-      return extractApiArray<DailyReadingSummary>(response, 'readings');
+      return extractApiArray<DailyReadingSummary>(response);
     } catch (error) {
       console.error('Error fetching daily readings summary:', error);
       return [];
@@ -32,7 +32,7 @@ export const reconciliationApi = {
       if (stationId) params.append('stationId', stationId);
       
       const response = await apiClient.get(`/reconciliation?${params.toString()}`);
-      return extractApiArray<ReconciliationRecord>(response, 'reconciliations');
+      return extractApiArray<ReconciliationRecord>(response);
     } catch (error) {
       console.error('Error fetching reconciliation history:', error);
       return [];

--- a/src/api/sales.ts
+++ b/src/api/sales.ts
@@ -44,22 +44,7 @@ export const salesApi = {
       console.log('[SALES-API] Applied filters:', filters);
       
       const response = await apiClient.get(url);
-      console.log('[SALES-API] Raw response:', response.data);
-      
-      let rawSales = extractApiArray<any>(response, 'sales');
-      
-      // If no sales found with standard extraction, try alternatives
-      if (rawSales.length === 0 && response.data) {
-        console.log('[SALES-API] Trying alternative extraction methods');
-        
-        if (Array.isArray(response.data)) {
-          rawSales = response.data;
-        } else if (response.data.data && Array.isArray(response.data.data)) {
-          rawSales = response.data.data;
-        } else if (response.data.results && Array.isArray(response.data.results)) {
-          rawSales = response.data.results;
-        }
-      }
+      const rawSales = extractApiArray<any>(response);
       
       // Transform backend data to frontend format
       const transformedSales = rawSales.map(transformSale);

--- a/src/api/stations.ts
+++ b/src/api/stations.ts
@@ -39,7 +39,7 @@ export const stationsApi = {
     try {
       const params = includeMetrics ? { includeMetrics: 'true' } : {};
       const response = await apiClient.get('/stations', { params });
-      return extractApiArray<Station>(response, 'stations');
+      return extractApiArray<Station>(response);
     } catch (error) {
       console.error('Error fetching stations:', error);
       return [];
@@ -92,7 +92,7 @@ export const stationsApi = {
   // Get performance comparison for a station
   getStationPerformance: async (id: string): Promise<StationComparison[]> => {
     const response = await apiClient.get(`/stations/${id}/performance`);
-    return extractApiArray<StationComparison>(response, 'data');
+    return extractApiArray<StationComparison>(response);
   },
 
   // Get efficiency metric for a station

--- a/src/api/superadmin.ts
+++ b/src/api/superadmin.ts
@@ -47,7 +47,7 @@ export const superadminApi = {
   getTenants: async (): Promise<Tenant[]> => {
     devLog('Fetching all tenants');
     const response = await apiClient.get('/admin/tenants');
-    return extractApiArray<Tenant>(response, 'tenants');
+    return extractApiArray<Tenant>(response);
   },
 
   createTenant: async (data: CreateTenantRequest): Promise<Tenant> => {
@@ -127,7 +127,7 @@ export const superadminApi = {
   getAdminUsers: async (): Promise<AdminUser[]> => {
     devLog('Fetching all admin users');
     const response = await apiClient.get('/admin/users');
-    return extractApiArray<AdminUser>(response, 'users');
+    return extractApiArray<AdminUser>(response);
   },
 
   createAdminUser: async (data: CreateSuperAdminRequest): Promise<AdminUser> => {

--- a/src/api/tenant-settings.ts
+++ b/src/api/tenant-settings.ts
@@ -14,7 +14,7 @@ export const tenantSettingsApi = {
   getTenantSettings: async (): Promise<TenantSetting[]> => {
     try {
       const response = await apiClient.get('/tenant/settings');
-      return extractApiArray<TenantSetting>(response, 'settings');
+      return extractApiArray<TenantSetting>(response);
     } catch (error) {
       console.error('[TENANT-SETTINGS] Error fetching tenant settings:', error);
       if (error.response?.data?.message) {
@@ -46,7 +46,7 @@ export const tenantSettingsApi = {
   getTenantSettingsForTenant: async (tenantId: string): Promise<TenantSetting[]> => {
     try {
       const response = await apiClient.get(`/admin/tenants/${tenantId}/settings`);
-      return extractApiArray<TenantSetting>(response, 'settings');
+      return extractApiArray<TenantSetting>(response);
     } catch (error) {
       console.error(`[TENANT-SETTINGS] Error fetching settings for tenant ${tenantId}:`, error);
       if (error.response?.data?.message) {

--- a/src/api/tenants.ts
+++ b/src/api/tenants.ts
@@ -26,7 +26,7 @@ export const tenantsApi = {
     try {
       console.log('Fetching tenants from SuperAdmin endpoint /admin/tenants');
       const response = await apiClient.get('/admin/tenants');
-      const tenants = extractApiArray<TenantResponse>(response, 'tenants');
+      const tenants = extractApiArray<TenantResponse>(response);
       
       // Map the tenant structure to the expected Tenant structure
       return tenants.map(tenant => ({

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -15,7 +15,7 @@ export const usersApi = {
   getUsers: async (): Promise<User[]> => {
     try {
       const response = await apiClient.get('/users');
-      return extractApiArray<User>(response, 'users');
+      return extractApiArray<User>(response);
     } catch (error) {
       console.error('Error fetching users:', error);
       return [];
@@ -59,7 +59,7 @@ export const usersApi = {
   getSuperAdminUsers: async (): Promise<User[]> => {
     try {
       const response = await apiClient.get('/admin/users');
-      return extractApiArray<User>(response, 'users');
+      return extractApiArray<User>(response);
     } catch (error) {
       console.error('Error fetching super admin users:', error);
       return [];


### PR DESCRIPTION
## Summary
- align API hooks with `{ success, data }` spec
- drop legacy array keys and fallbacks
- document OpenAPI hook alignment fix

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npx vitest run` *(fails: needs package installation)*

------
https://chatgpt.com/codex/tasks/task_e_6867e7a8fed88320b1b5db5f1f968183