### PR TITLE
Fix dashboard hook and align test route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,3 +116,4 @@ All notable changes to this project will be documented in this file.
 
 ### [refactor] Consolidate hooks structure and update imports
 ### [fix] Remove deprecated dashboard API usage
+### [fix] Use service for admin dashboard and standard error response

--- a/fuelsync/docs/IMPLEMENTATION_INDEX.md
+++ b/fuelsync/docs/IMPLEMENTATION_INDEX.md
@@ -223,3 +223,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.56 | Backend analytics and inventory completion | ✅ Done | `src/services/analytics.service.ts`, `src/services/fuelInventory.service.ts`, `src/services/tenant.service.ts`, `src/controllers`, `src/routes`, `docs/openapi.yaml` | `docs/STEP_2_56_COMMAND.md` |
 | fix | 2025-12-02 | Frontend hooks OpenAPI alignment | ✅ Done | src/api/* | docs/STEP_fix_20251202.md |
 | fix | 2025-12-03 | Remove deprecated dashboard API usage | ✅ Done | src/api/dashboard.ts, dashboard components | docs/STEP_fix_20251203.md |
+| fix | 2025-12-04 | API service and hook consistency | ✅ Done | src/hooks/useDashboard.ts, fuelsync/src/routes/auth.route.ts | docs/STEP_fix_20251204.md |

--- a/fuelsync/docs/PHASE_3_SUMMARY.md
+++ b/fuelsync/docs/PHASE_3_SUMMARY.md
@@ -123,3 +123,4 @@ database and backend docs are updated before the frontend adjusts.
 
 Updated dashboard components to use `/dashboard/fuel-breakdown` and `/dashboard/sales-trend` as per latest OpenAPI.
 
+\n### \ud83d\udcc4 Documentation Addendum – 2025-12-04\n\nRefactored admin dashboard hook to use superadmin API service and standardized auth route test response.

--- a/fuelsync/docs/STEP_fix_20251204.md
+++ b/fuelsync/docs/STEP_fix_20251204.md
@@ -1,0 +1,14 @@
+# STEP_fix_20251204.md — API service and hook consistency
+
+## Project Context Summary
+FuelSync Hub uses React Query hooks to access backend services. APIs follow the `{ success, data }` response pattern with `successResponse` and `errorResponse` helpers. Previous steps ensured most hooks rely on typed API services but an inline `fetch` remained for the admin dashboard.
+
+## What Was Done Now
+- Replaced the inline `fetch` call in `useDashboard.ts` with `superadminApi.getSummary` for reuse and consistent typing.
+- Updated the `/auth/test` route to use `successResponse` instead of a raw `res.json` call.
+- Scanned hooks and services for hard-coded tenant or station IDs and none were found.
+- Verified all controllers return responses via `successResponse`/`errorResponse`.
+
+## Required Documentation Updates
+- Add changelog entry under Fixes.
+- Record this fix in `IMPLEMENTATION_INDEX.md`.

--- a/fuelsync/src/routes/auth.route.ts
+++ b/fuelsync/src/routes/auth.route.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import { Pool } from 'pg';
 import { createAuthController } from '../controllers/auth.controller';
 import { authenticateJWT } from '../middlewares/authenticateJWT';
+import { successResponse } from '../utils/successResponse';
 
 export function createAuthRouter(db: Pool) {
   const router = Router();
@@ -14,7 +15,7 @@ export function createAuthRouter(db: Pool) {
   // Add a simple test endpoint
   router.get('/test', (_req, res) => {
     console.log('[AUTH-ROUTE] Test endpoint called');
-    return res.json({ status: 'ok', message: 'Auth API is working' });
+    return successResponse(res, { status: 'ok' }, 'Auth API is working');
   });
 
   return router;

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -2,6 +2,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { dashboardApi } from '@/api/dashboard';
 import { analyticsApi } from '@/api/analytics';
+import { superadminApi } from '@/api/superadmin';
 
 interface DashboardFilters {
   stationId?: string;
@@ -76,11 +77,7 @@ export const useAnalyticsDashboard = () => {
 export const useAdminDashboard = () => {
   return useQuery({
     queryKey: ['admin-dashboard'],
-    queryFn: async () => {
-      // This would call /api/v1/admin/dashboard
-      const response = await fetch('/api/v1/admin/dashboard');
-      return response.json();
-    },
+    queryFn: () => superadminApi.getSummary(),
     retry: 1,
     staleTime: 300000,
   });


### PR DESCRIPTION
## Summary
- use superadmin API in `useDashboard` hook
- standardize `/auth/test` response with `successResponse`
- document API service consistency fix

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867f1c052c88320838a11846d8ea13c