### PR TITLE
Update tenant email pattern

### DIFF
--- a/fuelsync/TENANT_USER_CREATION_PROCESS.md
+++ b/fuelsync/TENANT_USER_CREATION_PROCESS.md
@@ -16,19 +16,19 @@ When a new tenant is created, the system:
 ### 2. Automatic User Creation
 
 #### Owner User (Primary Admin)
-- **Email**: `owner@{tenant-slug}.com` (e.g., `owner@acme-corp.com`)
+- **Email**: `owner@{tenant-slug}.fuelsync.com` (e.g., `owner@acme-corp.fuelsync.com`)
 - **Password**: `{firstname}@{schema}123` (e.g., `acme@tenant123`)
 - **Role**: `owner` - Full system access
 - **Name**: `{Tenant Name} Owner` (e.g., `Acme Corp Owner`)
 
 #### Manager User (Operations Manager)
-- **Email**: `manager@{tenant-slug}.com`
+- **Email**: `manager@{tenant-slug}.fuelsync.com`
 - **Password**: `{firstname}@{schema}123`
 - **Role**: `manager` - Station management, reports, user management
 - **Name**: `{Tenant Name} Manager`
 
 #### Attendant User (Station Operator)
-- **Email**: `attendant@{tenant-slug}.com`
+- **Email**: `attendant@{tenant-slug}.fuelsync.com`
 - **Password**: `{firstname}@{schema}123`
 - **Role**: `attendant` - Basic operations, readings entry
 - **Name**: `{Tenant Name} Attendant`

--- a/fuelsync/UNIFIED_DB_SETUP.md
+++ b/fuelsync/UNIFIED_DB_SETUP.md
@@ -96,7 +96,7 @@ The seed script creates the following data:
   - Password: Admin@123
 
 - **Tenant Owner**:
-  - Email: owner@demofuels.com
+  - Email: owner@demofuels.fuelsync.com
   - Password: Owner@123
 
 ### Demo Tenant Infrastructure

--- a/fuelsync/docs/CHANGELOG.md
+++ b/fuelsync/docs/CHANGELOG.md
@@ -2862,4 +2862,18 @@ Each entry is tied to a step from the implementation index.
 * `src/routes/*`
 * `docs/openapi.yaml`
 * `docs/STEP_2_56_COMMAND.md`
+## [Step 2.57] – Tenant email convention update
+
+### 🟦 Enhancements
+* Default user emails now use `<role>@<schema>.fuelsync.com` pattern for clarity.
+
+### Files
+* `src/services/tenant.service.ts`
+* `docs/TENANT_CREATION_API.md`
+* `docs/TENANT_MANAGEMENT_GUIDE.md`
+* `TENANT_USER_CREATION_PROCESS.md`
+* `docs/USER_MANAGEMENT.md`
+* `UNIFIED_DB_SETUP.md`
+* `docs/STEP_2_57_COMMAND.md`
 \n## [Step 3.8] – Final QA Audit\n\n### 🟦 Enhancements\n* Verified OpenAPI, backend routes and frontend hooks are aligned.\n* Documented results in `QA_AUDIT_REPORT.md`.\n\n### Files\n* `docs/QA_AUDIT_REPORT.md`\n* `docs/STEP_3_8_COMMAND.md`\n
+

--- a/fuelsync/docs/IMPLEMENTATION_INDEX.md
+++ b/fuelsync/docs/IMPLEMENTATION_INDEX.md
@@ -221,6 +221,7 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | 2     | 2.55 | Dashboard station metrics endpoint | ✅ Done | `src/services/station.service.ts`, `src/controllers/dashboard.controller.ts`, `src/routes/dashboard.route.ts`, `docs/openapi.yaml` | `PHASE_2_SUMMARY.md#step-2.55` |
 | fix | 2025-12-01 | Alert parameter naming alignment | ✅ Done | `docs/openapi.yaml`, `frontend/docs/openapi-v1.yaml` | `docs/STEP_fix_20251201.md` |
 | 2     | 2.56 | Backend analytics and inventory completion | ✅ Done | `src/services/analytics.service.ts`, `src/services/fuelInventory.service.ts`, `src/services/tenant.service.ts`, `src/controllers`, `src/routes`, `docs/openapi.yaml` | `docs/STEP_2_56_COMMAND.md` |
+| 2     | 2.57 | Tenant email convention update | ✅ Done | `src/services/tenant.service.ts`, `docs/TENANT_CREATION_API.md`, `docs/TENANT_MANAGEMENT_GUIDE.md`, `TENANT_USER_CREATION_PROCESS.md`, `docs/USER_MANAGEMENT.md`, `UNIFIED_DB_SETUP.md` | `docs/STEP_2_57_COMMAND.md` |
 | fix | 2025-12-02 | Frontend hooks OpenAPI alignment | ✅ Done | src/api/* | docs/STEP_fix_20251202.md |
 | fix | 2025-12-03 | Remove deprecated dashboard API usage | ✅ Done | src/api/dashboard.ts, dashboard components | docs/STEP_fix_20251203.md |
 | fix | 2025-12-04 | API service and hook consistency | ✅ Done | src/hooks/useDashboard.ts, fuelsync/src/routes/auth.route.ts | docs/STEP_fix_20251204.md |

--- a/fuelsync/docs/PHASE_2_SUMMARY.md
+++ b/fuelsync/docs/PHASE_2_SUMMARY.md
@@ -1235,6 +1235,13 @@ sudo apt-get update && sudo apt-get install -y postgresql
 * Auth responses now return tenant name and fuel price list includes station name.
 * Marked testing endpoints as internal in API docs.
 
+### 🛠️ Step 2.57 – Tenant email convention update
+**Status:** ✅ Done
+**Files:** `src/services/tenant.service.ts`, `docs/TENANT_CREATION_API.md`, `docs/TENANT_MANAGEMENT_GUIDE.md`, `TENANT_USER_CREATION_PROCESS.md`, `docs/USER_MANAGEMENT.md`, `UNIFIED_DB_SETUP.md`, `docs/STEP_2_57_COMMAND.md`
+
+**Overview:**
+* Default user emails now follow `<role>@<schema>.fuelsync.com` for predictability.
+
 ### 🛠️ Fix 2025-12-02 – Frontend hooks OpenAPI alignment
 **Status:** ✅ Done
 **Files:** `src/api/*`, `CHANGELOG.md`, `docs/STEP_fix_20251202.md`

--- a/fuelsync/docs/STEP_2_57_COMMAND.md
+++ b/fuelsync/docs/STEP_2_57_COMMAND.md
@@ -1,0 +1,24 @@
+# STEP_2_57_COMMAND.md — Tenant email convention update
+
+## Project Context Summary
+FuelSync Hub is a multi-tenant ERP with schema-per-tenant. The tenant service automatically creates owner, manager and attendant users when a tenant is created. Currently the generated emails follow the pattern `owner@{tenant-slug}.com`. Documentation such as `TENANT_CREATION_API.md` and `TENANT_MANAGEMENT_GUIDE.md` describe this behaviour.
+
+## Steps Already Implemented
+- Tenant creation with automatic user generation using slug-based emails
+- Backend analytics and inventory endpoints (`STEP_2_56_COMMAND.md`)
+- Frontend password change form and hooks
+
+## What to Build Now
+Update tenant user seeding logic and docs to use a consistent domain-based email pattern:
+`{role}@{schema}.fuelsync.com`. Emails must remain unique per tenant schema. Update documentation examples accordingly.
+
+## Files to Update
+- `fuelsync/src/services/tenant.service.ts`
+- `fuelsync/docs/TENANT_CREATION_API.md`
+- `fuelsync/docs/TENANT_MANAGEMENT_GUIDE.md`
+- `fuelsync/TENANT_USER_CREATION_PROCESS.md`
+- `fuelsync/docs/USER_MANAGEMENT.md`
+- `fuelsync/UNIFIED_DB_SETUP.md`
+- `fuelsync/docs/CHANGELOG.md`
+- `fuelsync/docs/PHASE_2_SUMMARY.md`
+- `fuelsync/docs/IMPLEMENTATION_INDEX.md`

--- a/fuelsync/docs/TENANT_CREATION_API.md
+++ b/fuelsync/docs/TENANT_CREATION_API.md
@@ -47,9 +47,9 @@ The API accepts the following formats:
 
 1. A new record is added to the `public.tenants` table
 2. Default users are created for the tenant:
-   - Owner (`owner@{tenant-slug}.com`)
-   - Manager (`manager@{tenant-slug}.com`)
-   - Attendant (`attendant@{tenant-slug}.com`)
+   - Owner (`owner@{tenant-slug}.fuelsync.com`)
+   - Manager (`manager@{tenant-slug}.fuelsync.com`)
+   - Attendant (`attendant@{tenant-slug}.fuelsync.com`)
 
 ## User Management After Tenant Creation
 

--- a/fuelsync/docs/TENANT_MANAGEMENT_GUIDE.md
+++ b/fuelsync/docs/TENANT_MANAGEMENT_GUIDE.md
@@ -22,17 +22,17 @@ Active ↔ Suspended ↔ Cancelled → Deleted
 When creating a tenant, the system automatically creates:
 
 1. **Owner User**
-   - Email: `owner@{tenant-slug}.com`
+   - Email: `owner@{tenant-slug}.fuelsync.com`
    - Password: `{firstname}@tenant123`
    - Role: Full system access
 
 2. **Manager User**
-   - Email: `manager@{tenant-slug}.com`
+   - Email: `manager@{tenant-slug}.fuelsync.com`
    - Password: `{firstname}@tenant123`
    - Role: Station management, reports
 
 3. **Attendant User**
-   - Email: `attendant@{tenant-slug}.com`
+   - Email: `attendant@{tenant-slug}.fuelsync.com`
    - Password: `{firstname}@tenant123`
    - Role: Basic operations, readings
 

--- a/fuelsync/docs/USER_MANAGEMENT.md
+++ b/fuelsync/docs/USER_MANAGEMENT.md
@@ -24,11 +24,11 @@ FuelSync has three user roles within each tenant:
 
 When a tenant is created, an owner user is automatically created with:
 
-- **Email**: `owner@tenant-schema-name.com` (underscores replaced with hyphens)
+- **Email**: `owner@tenant-schema-name.fuelsync.com` (underscores replaced with hyphens)
 - **Password**: `tenant123`
 - **Role**: `owner`
 
-For example, if you create a tenant with schema name `acme_fuels`, the owner's email will be `owner@acme-fuels.com`.
+For example, if you create a tenant with schema name `acme_fuels`, the owner's email will be `owner@acme-fuels.fuelsync.com`.
 
 ## User Management APIs
 

--- a/fuelsync/src/services/tenant.service.ts
+++ b/fuelsync/src/services/tenant.service.ts
@@ -60,7 +60,8 @@ export async function createTenant(db: Pool, input: TenantInput): Promise<Tenant
 
     const tenantSlug = slugify(input.name);
     const ownerName = input.ownerName || `${input.name} Owner`;
-    const ownerEmail = input.ownerEmail || `owner@${tenantSlug}.com`;
+    const ownerEmail =
+      input.ownerEmail || `owner@${tenantSlug}.fuelsync.com`;
     const rawPassword = input.ownerPassword || generatePassword(input.name);
     const passwordHash = await import('bcrypt').then(bcrypt => bcrypt.hash(rawPassword, 10));
 
@@ -71,7 +72,7 @@ export async function createTenant(db: Pool, input: TenantInput): Promise<Tenant
 
     const ownerId = ownerResult.rows[0].id;
 
-    const managerEmail = `manager@${tenantSlug}.com`;
+    const managerEmail = `manager@${tenantSlug}.fuelsync.com`;
     const managerPassword = generatePassword(`${input.name} Manager`);
     const managerHash = await import('bcrypt').then(bcrypt => bcrypt.hash(managerPassword, 10));
 
@@ -80,7 +81,7 @@ export async function createTenant(db: Pool, input: TenantInput): Promise<Tenant
       [randomUUID(), tenant.id, managerEmail, managerHash, `${input.name} Manager`, 'manager']
     );
 
-    const attendantEmail = `attendant@${tenantSlug}.com`;
+    const attendantEmail = `attendant@${tenantSlug}.fuelsync.com`;
     const attendantPassword = generatePassword(`${input.name} Attendant`);
     const attendantHash = await import('bcrypt').then(bcrypt => bcrypt.hash(attendantPassword, 10));
 


### PR DESCRIPTION
## Summary
- auto-create tenant emails using `<role>@<schema>.fuelsync.com`
- document the new email convention across guides
- log the change in CHANGELOG and phase summary
- track the step in IMPLEMENTATION_INDEX

## Testing
- `npm test --prefix fuelsync`

------
https://chatgpt.com/codex/tasks/task_e_686808f0bcdc8320bc69768e66c9407e