### PR TITLE
Fix dashboard data and add fuel prices card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,3 +122,5 @@ All notable changes to this project will be documented in this file.
 ### [fix] Remove unused single-report and reading API endpoints
 ### [docs] Prisma usage audit and recommendations
 ### [refactor] Replace pg queries with Prisma in services and analytics
+### [feature] Display latest fuel prices on dashboard
+### [fix] Forward filters in top creditors API

--- a/docs/STEP_fix_20251208.md
+++ b/docs/STEP_fix_20251208.md
@@ -1,0 +1,18 @@
+# STEP_fix_20251208.md — Owner dashboard data fixes
+
+## Project Context Summary
+Owner dashboard cards were rendering but no data appeared. Previous refactors removed deprecated paths, but some hooks still missed filter support and the dashboard lacked visibility of latest fuel prices.
+
+## Steps Already Implemented
+- Dashboard hooks aligned with OpenAPI (`STEP_fix_20251203.md`).
+- Prisma service migration (`STEP_fix_20251207.md`).
+
+## What Was Done Now
+- Updated `dashboardApi.getTopCreditors` and related hook to forward filter params.
+- Added `LatestFuelPricesCard` component showing most recent prices per fuel type.
+- Integrated this card on `SummaryPage` next to the sales trend chart.
+
+## Required Documentation Updates
+- Add changelog entry under Fixes and Features.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_3_SUMMARY.md`.

--- a/fuelsync/docs/IMPLEMENTATION_INDEX.md
+++ b/fuelsync/docs/IMPLEMENTATION_INDEX.md
@@ -231,3 +231,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-12-06 | Prisma usage audit | ✅ Done | `docs/PRISMA_EFFICIENCY_REVIEW.md` | `docs/STEP_fix_20251206.md` |
 | fix | 2025-12-07 | Prisma migration of services | ✅ Done | `src/services/user.service.ts`, `src/services/pump.service.ts`, `src/controllers/analytics.controller.ts` | `docs/STEP_fix_20251207.md` |
 | 3     | 3.8  | Final QA audit and API alignment | ✅ Done | `docs/STEP_3_8_COMMAND.md`, `docs/QA_AUDIT_REPORT.md` | `PHASE_3_SUMMARY.md#step-3.8` |
+| fix | 2025-12-08 | Owner dashboard data fixes | ✅ Done | `src/api/dashboard.ts`, `src/hooks/useDashboard.ts`, `src/components/dashboard/LatestFuelPricesCard.tsx`, `src/pages/dashboard/SummaryPage.tsx` | `docs/STEP_fix_20251208.md` |

--- a/fuelsync/docs/PHASE_3_SUMMARY.md
+++ b/fuelsync/docs/PHASE_3_SUMMARY.md
@@ -173,3 +173,7 @@ Updated dashboard components to use `/dashboard/fuel-breakdown` and `/dashboard/
 
 \n### \ud83d\udcc4 Documentation Addendum – 2025-12-04\n\nRefactored admin dashboard hook to use superadmin API service and standardized auth route test response.
 \n### 🖼️ Step 3.8 – Final QA Audit\n\n**Status:** ✅ Done\n**Files:** `docs/QA_AUDIT_REPORT.md`\n\n**Business Rules Covered:**\n\n* Ensure frontend and backend are fully aligned with OpenAPI.\n\n**Validation Performed:**\n\n* Reviewed endpoints, hooks and pages for completion.\n
+
+### 📄 Documentation Addendum – 2025-12-08
+
+Integrated latest fuel prices widget on the Owner dashboard and fixed missing filter parameters for top creditors.

--- a/src/api/dashboard.ts
+++ b/src/api/dashboard.ts
@@ -37,9 +37,12 @@ export const dashboardApi = {
     return extractApiArray<FuelTypeBreakdown>(response);
   },
 
-  getTopCreditors: async (limit: number = 5): Promise<TopCreditor[]> => {
+  getTopCreditors: async (
+    limit: number = 5,
+    filters: DashboardFilters = {}
+  ): Promise<TopCreditor[]> => {
     const response = await apiClient.get('/dashboard/top-creditors', {
-      params: { limit }
+      params: { limit, ...filters }
     });
     return extractApiArray<TopCreditor>(response);
   },

--- a/src/components/dashboard/LatestFuelPricesCard.tsx
+++ b/src/components/dashboard/LatestFuelPricesCard.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Fuel } from 'lucide-react';
+import { useFuelPrices } from '@/hooks/useFuelPrices';
+
+interface DashboardFilters {
+  stationId?: string;
+}
+
+interface LatestFuelPricesCardProps {
+  filters?: DashboardFilters;
+}
+
+export function LatestFuelPricesCard({ filters = {} }: LatestFuelPricesCardProps) {
+  const { data: prices = [], isLoading } = useFuelPrices();
+
+  const filtered = filters.stationId
+    ? prices.filter(p => p.stationId === filters.stationId)
+    : prices;
+
+  const latest: Record<string, { price: number; validFrom: string }> = {};
+  for (const price of filtered) {
+    const existing = latest[price.fuelType];
+    if (!existing || new Date(price.validFrom) > new Date(existing.validFrom)) {
+      latest[price.fuelType] = { price: price.price, validFrom: price.validFrom };
+    }
+  }
+
+  const fuelTypes = Object.keys(latest);
+
+  return (
+    <Card className="bg-gradient-to-br from-white to-yellow-50 border-yellow-200">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-yellow-700">
+          <Fuel className="h-5 w-5" /> Latest Fuel Prices
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-24 bg-muted animate-pulse rounded" />
+        ) : fuelTypes.length ? (
+          <ul className="space-y-2">
+            {fuelTypes.map(ft => (
+              <li key={ft} className="flex justify-between">
+                <span className="capitalize">{ft}</span>
+                <span className="font-mono">₹{latest[ft].price.toFixed(2)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-muted-foreground">No price data available</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -40,7 +40,7 @@ export const useFuelTypeBreakdown = (filters: DashboardFilters = {}) => {
 export const useTopCreditors = (limit: number = 5, filters: DashboardFilters = {}) => {
   return useQuery({
     queryKey: ['top-creditors', limit, filters],
-    queryFn: () => dashboardApi.getTopCreditors(limit),
+    queryFn: () => dashboardApi.getTopCreditors(limit, filters),
     retry: 1,
     staleTime: 60000,
   });

--- a/src/pages/dashboard/SummaryPage.tsx
+++ b/src/pages/dashboard/SummaryPage.tsx
@@ -11,6 +11,7 @@ import { SalesSummaryCard } from '@/components/dashboard/SalesSummaryCard';
 import { PaymentMethodChart } from '@/components/dashboard/PaymentMethodChart';
 import { FuelBreakdownChart } from '@/components/dashboard/FuelBreakdownChart';
 import { SalesTrendChart } from '@/components/dashboard/SalesTrendChart';
+import { LatestFuelPricesCard } from '@/components/dashboard/LatestFuelPricesCard';
 import { ProfitMetricsCard } from '@/components/dashboard/ProfitMetricsCard';
 import { TopCreditorsTable } from '@/components/dashboard/TopCreditorsTable';
 import { StationMetricsCard } from '@/components/dashboard/StationMetricsCard';
@@ -178,8 +179,9 @@ export default function SummaryPage() {
         <FuelBreakdownChart filters={filters} />
       </div>
 
-      <div className="grid grid-cols-1 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
         <SalesTrendChart filters={filters} />
+        <LatestFuelPricesCard filters={filters} />
       </div>
 
       {/* Station Metrics and Top Creditors */}


### PR DESCRIPTION
## Summary
- forward filters to getTopCreditors API
- show latest fuel prices on the Owner dashboard
- document dashboard fix step

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68681185ef8483209708483e954b4a03