### PR TITLE
Fix: modernize stations page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,3 +124,4 @@ All notable changes to this project will be documented in this file.
 ### [refactor] Replace pg queries with Prisma in services and analytics
 ### [feature] Display latest fuel prices on dashboard
 ### [fix] Forward filters in top creditors API
+### [enhancement] Updated stations page UI with StationCard component

--- a/docs/STEP_fix_20251209.md
+++ b/docs/STEP_fix_20251209.md
@@ -1,0 +1,18 @@
+# STEP_fix_20251209.md — Stations page UI refresh
+
+## Project Context Summary
+The station list page still used older card styles and lacked edit/delete actions. Pump and nozzle pages already utilise colorful cards with standard controls.
+
+## Steps Already Implemented
+- `STEP_fix_20251208.md` added latest fuel prices and hook fixes.
+
+## What Was Done Now
+- Created `StationCard` component with modern layout.
+- Refactored `StationsPage` to use this component, added breadcrumbs and floating create button.
+- Wired delete action via `useDeleteStation` hook with success/error toasts.
+- Hidden create button for attendants.
+
+## Required Documentation Updates
+- Add changelog entry under Enhancements.
+- Append row to `IMPLEMENTATION_INDEX.md`.
+- Summarise in `PHASE_3_SUMMARY.md`.

--- a/fuelsync/docs/IMPLEMENTATION_INDEX.md
+++ b/fuelsync/docs/IMPLEMENTATION_INDEX.md
@@ -232,3 +232,4 @@ This file tracks every build step taken by AI agents or developers. It maintains
 | fix | 2025-12-07 | Prisma migration of services | ✅ Done | `src/services/user.service.ts`, `src/services/pump.service.ts`, `src/controllers/analytics.controller.ts` | `docs/STEP_fix_20251207.md` |
 | 3     | 3.8  | Final QA audit and API alignment | ✅ Done | `docs/STEP_3_8_COMMAND.md`, `docs/QA_AUDIT_REPORT.md` | `PHASE_3_SUMMARY.md#step-3.8` |
 | fix | 2025-12-08 | Owner dashboard data fixes | ✅ Done | `src/api/dashboard.ts`, `src/hooks/useDashboard.ts`, `src/components/dashboard/LatestFuelPricesCard.tsx`, `src/pages/dashboard/SummaryPage.tsx` | `docs/STEP_fix_20251208.md` |
+| fix | 2025-12-09 | Stations page UI refresh | ✅ Done | `src/pages/dashboard/StationsPage.tsx`, `src/components/stations/StationCard.tsx` | `docs/STEP_fix_20251209.md` |

--- a/fuelsync/docs/PHASE_3_SUMMARY.md
+++ b/fuelsync/docs/PHASE_3_SUMMARY.md
@@ -177,3 +177,4 @@ Updated dashboard components to use `/dashboard/fuel-breakdown` and `/dashboard/
 ### 📄 Documentation Addendum – 2025-12-08
 
 Integrated latest fuel prices widget on the Owner dashboard and fixed missing filter parameters for top creditors.
+\n### 📄 Documentation Addendum – 2025-12-09\n\nRefactored Stations page to use new StationCard component with edit/delete controls and floating create button.

--- a/src/components/stations/StationCard.tsx
+++ b/src/components/stations/StationCard.tsx
@@ -1,0 +1,120 @@
+import { Button } from '@/components/ui/button';
+import { ColorfulCard, CardContent, CardHeader } from '@/components/ui/colorful-card';
+import { StatusBadge } from '@/components/ui/status-badge';
+import { Eye, Edit, Trash2, Settings, Fuel, Building2, DollarSign } from 'lucide-react';
+
+interface StationCardProps {
+  station: {
+    id: string;
+    name: string;
+    address: string;
+    status: string;
+    pumpCount: number;
+    metrics?: { totalSales?: number };
+  };
+  onView: (id: string) => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onSettings?: (id: string) => void;
+  onViewPumps?: (id: string) => void;
+}
+
+export function StationCard({
+  station,
+  onView,
+  onEdit,
+  onDelete,
+  onSettings,
+  onViewPumps,
+}: StationCardProps) {
+  const getGradientByStatus = (status: string) => {
+    switch (status.toLowerCase()) {
+      case 'active':
+        return 'from-green-50 via-emerald-50 to-teal-50 border-green-200';
+      case 'maintenance':
+        return 'from-yellow-50 via-orange-50 to-amber-50 border-yellow-200';
+      case 'inactive':
+        return 'from-red-50 via-pink-50 to-rose-50 border-red-200';
+      default:
+        return 'from-gray-50 via-slate-50 to-zinc-50 border-gray-200';
+    }
+  };
+
+  return (
+    <ColorfulCard gradient={getGradientByStatus(station.status)} className="border">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0 flex-1">
+            <div className="p-2 bg-blue-100 rounded-lg">
+              <Building2 className="h-5 w-5 text-blue-600" />
+            </div>
+            <div className="min-w-0 flex-1">
+              <h3 className="font-semibold text-gray-900 text-base sm:text-lg truncate">
+                {station.name}
+              </h3>
+              <p className="text-xs text-gray-600 truncate">
+                {station.address}
+              </p>
+            </div>
+          </div>
+          <StatusBadge status={station.status} size="sm" />
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0 space-y-3">
+        <div className="grid grid-cols-2 gap-3">
+          <div className="bg-white/60 rounded-lg p-2 backdrop-blur-sm">
+            <div className="flex items-center gap-2">
+              <Fuel className="h-4 w-4 text-gray-600" />
+              <div>
+                <p className="text-xs text-gray-600">Pumps</p>
+                <p className="font-bold text-gray-900">{station.pumpCount}</p>
+              </div>
+            </div>
+          </div>
+          <div className="bg-white/60 rounded-lg p-2 backdrop-blur-sm">
+            <div className="flex items-center gap-2">
+              <DollarSign className="h-4 w-4 text-gray-600" />
+              <div>
+                <p className="text-xs text-gray-600">Today's Sales</p>
+                <p className="font-bold text-gray-900">
+                  ₹{station.metrics?.totalSales?.toLocaleString() || 0}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-2 pt-1">
+          <Button variant="default" size="sm" className="flex-1" onClick={() => onView(station.id)}>
+            <Eye className="w-4 h-4 mr-1" />
+            <span className="hidden sm:inline">View</span>
+          </Button>
+          <Button variant="outline" size="sm" className="flex-1" onClick={() => onEdit(station.id)}>
+            <Edit className="w-4 h-4 mr-1" />
+            <span className="hidden sm:inline">Edit</span>
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 text-red-600 hover:text-red-700"
+            onClick={() => onDelete(station.id)}
+          >
+            <Trash2 className="w-4 h-4 mr-1" />
+            <span className="hidden sm:inline">Delete</span>
+          </Button>
+          {onSettings && (
+            <Button variant="outline" size="sm" className="flex-1" onClick={() => onSettings(station.id)}>
+              <Settings className="w-4 h-4 mr-1" />
+              <span className="hidden sm:inline">Settings</span>
+            </Button>
+          )}
+          {onViewPumps && (
+            <Button variant="outline" size="sm" className="flex-1" onClick={() => onViewPumps(station.id)}>
+              <Fuel className="w-4 h-4 mr-1" />
+              <span className="hidden sm:inline">Pumps</span>
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </ColorfulCard>
+  );
+}


### PR DESCRIPTION
## Summary
- add StationCard component with colorful layout and actions
- refactor StationsPage to use StationCard and breadcrumbs
- hide create actions from attendants and add floating FAB
- document station page refresh

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6868167293548320a42ed0f39e62367d